### PR TITLE
v3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.7.13
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,16 @@ jobs:
         working-directory: ./bunja
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          NPM_TAG=latest
+
+          if [[ "$VERSION" == *-* ]]; then
+            NPM_TAG=${VERSION#*-}
+            NPM_TAG=${NPM_TAG%%.*}
+          fi
+
+          npm publish --provenance --access public --tag "$NPM_TAG"
         working-directory: ./bunja
 
       - name: Publish to JSR

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.7.13
 
       - name: Run tests
         run: deno test --allow-env

--- a/README.md
+++ b/README.md
@@ -264,12 +264,13 @@ or debugging code to visit those declared dependencies and fill in the graph.
 
 Prebaking runs bunja init functions in a dry graph-collection mode. It does not
 create ref-counted bunja instances, it does not mount dependencies, and it does
-not run `bunja.effect` callbacks.
+not run `bunja.effect` callbacks. Prebake still calls bunja init functions, so
+put external resource creation and subscriptions inside `bunja.effect` if they
+must not run during graph collection.
 
-`store.prebake` does not accept a seed for the root bunja. Dry-run values use
-each bunja's declared default seed, including dependencies reached through
-seeded refs. Keep external side effects inside `bunja.effect` so prebaking stays
-safe.
+`store.prebake` rejects root bunja refs that provide a seed. During dry-run
+initialization, bunja refs are converted to graph refs, so every prebaked bunja
+is initialized with its declared default seed.
 
 ```ts
 const result = store.prebake(selectedResourceBunja, readScope);

--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ function MyComponent() {
 }
 ```
 
+#### Seeding the first instance
+
+If a bunja needs creation-time data, use `bunja.withSeed`. A default seed is
+required when the bunja is declared, so callers may still omit the seed.
+
+The seed is used only when a matching bunja instance is first created. It is not
+part of the bunja instance identity. If the matching instance already exists,
+later seeds are ignored.
+
+Seeds can be supplied to `store.get`, `useBunja`, `bunja.use`, or `bunja.will`.
+
+```ts
+const formBunja = bunja.withSeed({ title: "" }, (seed) => {
+  const titleAtom = atom(seed.title);
+  return { titleAtom };
+});
+
+useBunja({ bunja: formBunja, seed: { title: "Draft" } });
+```
+
 ### Defining a Bunja that relies on other Bunja
 
 If you want to manage a state with a broad lifetime and another state with a
@@ -156,6 +176,111 @@ either `resourceFooBunja` or `resourceBarBunja`, since they depend on
 >
 > See: <https://github.com/facebook/react/issues/16728>
 
+#### Bunja init rules
+
+Inside a bunja initialization function, call `bunja.use` and `bunja.will`
+unconditionally and in the same order every time, similar to React's
+[Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks). Do not put
+them inside `if` statements, loops, or callbacks.
+
+The target passed to `bunja.use` or `bunja.will` must be static. If you pass
+scope value pairs as the second argument or through a bunja ref's `with` field,
+the list of scope bindings must also be static. Do not choose a different bunja
+or add/remove scope bindings based on runtime conditions.
+
+`seed` is the exception. A bunja ref may provide a dynamic `seed` value because
+seed is used only when creating the first matching bunja instance and is not
+recorded in the dependency graph.
+
+```ts
+const consumerBunja = bunja.withSeed({ currentUserId: "" }, (seed) => {
+  const getProfile = bunja.will({
+    // Must stay the same on every init.
+    bunja: profileBunja,
+    with: [
+      // Must stay the same on every init.
+      LocaleScope.bind("en-US"),
+    ],
+    // May change for each first instance creation.
+    seed: { currentUserId: seed.currentUserId },
+  });
+
+  return getProfile();
+});
+```
+
+If a dependency should only be used for one branch, declare it with `bunja.will`
+unconditionally, then branch on whether to call the returned thunk.
+
+#### Conditional dependencies
+
+Use `bunja.will` when a bunja may depend on another bunja only for a selected
+branch. `bunja.will` declares a possible dependency and returns a thunk. Only a
+called thunk becomes an active dependency and is mounted.
+
+The thunk may only be called during the same bunja initialization function that
+created it.
+
+```ts
+const resourceA = bunja(() => {
+  const { send } = bunja.use(websocketBunja);
+  bunja.effect(() => {
+    send("subscribe-a");
+    return () => send("unsubscribe-a");
+  });
+});
+
+const resourceB = bunja(() => {
+  const { send } = bunja.use(websocketBunja);
+  bunja.effect(() => {
+    send("subscribe-b");
+    return () => send("unsubscribe-b");
+  });
+});
+
+const selectedResourceBunja = bunja(() => {
+  const selected = bunja.use(SelectedResourceScope);
+  const useA = bunja.will(resourceA);
+  const useB = bunja.will(resourceB);
+
+  return selected === "a" ? useA() : useB();
+});
+```
+
+When a `bunja.will` thunk is called, the selected dependency becomes part of the
+current bunja instance. If that selected dependency resolves to a different
+instance because of scope values, the current bunja also resolves to a different
+instance.
+
+A declared but uncalled `bunja.will` dependency has no effect on the current
+bunja instance.
+
+#### Prebaking the dependency graph
+
+During normal `store.get` and `useBunja`, only the selected `bunja.will` branch
+is baked. If a declared `bunja.will` dependency is not called, that dependency's
+own dependencies may still be unknown. `store.prebake` can be used by devtools
+or debugging code to visit those declared dependencies and fill in the graph.
+
+Prebaking runs bunja init functions in a dry graph-collection mode. It does not
+create ref-counted bunja instances, it does not mount dependencies, and it does
+not run `bunja.effect` callbacks.
+
+`store.prebake` does not accept a seed for the root bunja. Dry-run values use
+each bunja's declared default seed, including dependencies reached through
+seeded refs. Keep external side effects inside `bunja.effect` so prebaking stays
+safe.
+
+```ts
+const result = store.prebake(selectedResourceBunja, readScope);
+
+result.relatedBunjas;
+result.requiredScopes;
+```
+
+The normal `store.get` and `useBunja` paths do not prebake automatically. They
+still mount only the active `bunja.will` branch.
+
 ### Dependency injection using Scope
 
 You can use a bunja for local state management.\
@@ -239,6 +364,11 @@ const UrlContext = createContext("https://example.com/");
 const UrlScope = createScopeFromContext(UrlContext);
 ```
 
+When using React 19, Bunja reads scope contexts lazily with `React.use`, so only
+the contexts needed by the active branch are read. With React 18, Bunja must
+read all bound contexts before resolving the bunja because `useContext` cannot
+be called conditionally. In React 18, call `bindScope` before rendering.
+
 #### Injecting dependencies directly into the scope
 
 You might want to use a bunja directly within a React component where the values
@@ -260,15 +390,15 @@ function MyComponent() {
 
 ##### Doing the same thing inside a bunja
 
-You can use `bunja.fork` to inject scope values from within a bunja
-initialization function.
+You can pass scope value pairs as the second argument to `bunja.use` to override
+scope values from within a bunja initialization function.
 
 ```ts
 const myBunja = bunja(() => {
-  const fooData = bunja.fork(fetchBunja, [
+  const fooData = bunja.use(fetchBunja, [
     UrlScope.bind("https://example.com/foo"),
   ]);
-  const barData = bunja.fork(fetchBunja, [
+  const barData = bunja.use(fetchBunja, [
     UrlScope.bind("https://example.com/bar"),
   ]);
 

--- a/bunja/README.md
+++ b/bunja/README.md
@@ -264,12 +264,13 @@ or debugging code to visit those declared dependencies and fill in the graph.
 
 Prebaking runs bunja init functions in a dry graph-collection mode. It does not
 create ref-counted bunja instances, it does not mount dependencies, and it does
-not run `bunja.effect` callbacks.
+not run `bunja.effect` callbacks. Prebake still calls bunja init functions, so
+put external resource creation and subscriptions inside `bunja.effect` if they
+must not run during graph collection.
 
-`store.prebake` does not accept a seed for the root bunja. Dry-run values use
-each bunja's declared default seed, including dependencies reached through
-seeded refs. Keep external side effects inside `bunja.effect` so prebaking stays
-safe.
+`store.prebake` rejects root bunja refs that provide a seed. During dry-run
+initialization, bunja refs are converted to graph refs, so every prebaked bunja
+is initialized with its declared default seed.
 
 ```ts
 const result = store.prebake(selectedResourceBunja, readScope);

--- a/bunja/README.md
+++ b/bunja/README.md
@@ -69,6 +69,26 @@ function MyComponent() {
 }
 ```
 
+#### Seeding the first instance
+
+If a bunja needs creation-time data, use `bunja.withSeed`. A default seed is
+required when the bunja is declared, so callers may still omit the seed.
+
+The seed is used only when a matching bunja instance is first created. It is not
+part of the bunja instance identity. If the matching instance already exists,
+later seeds are ignored.
+
+Seeds can be supplied to `store.get`, `useBunja`, `bunja.use`, or `bunja.will`.
+
+```ts
+const formBunja = bunja.withSeed({ title: "" }, (seed) => {
+  const titleAtom = atom(seed.title);
+  return { titleAtom };
+});
+
+useBunja({ bunja: formBunja, seed: { title: "Draft" } });
+```
+
 ### Defining a Bunja that relies on other Bunja
 
 If you want to manage a state with a broad lifetime and another state with a
@@ -156,6 +176,111 @@ either `resourceFooBunja` or `resourceBarBunja`, since they depend on
 >
 > See: <https://github.com/facebook/react/issues/16728>
 
+#### Bunja init rules
+
+Inside a bunja initialization function, call `bunja.use` and `bunja.will`
+unconditionally and in the same order every time, similar to React's
+[Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks). Do not put
+them inside `if` statements, loops, or callbacks.
+
+The target passed to `bunja.use` or `bunja.will` must be static. If you pass
+scope value pairs as the second argument or through a bunja ref's `with` field,
+the list of scope bindings must also be static. Do not choose a different bunja
+or add/remove scope bindings based on runtime conditions.
+
+`seed` is the exception. A bunja ref may provide a dynamic `seed` value because
+seed is used only when creating the first matching bunja instance and is not
+recorded in the dependency graph.
+
+```ts
+const consumerBunja = bunja.withSeed({ currentUserId: "" }, (seed) => {
+  const getProfile = bunja.will({
+    // Must stay the same on every init.
+    bunja: profileBunja,
+    with: [
+      // Must stay the same on every init.
+      LocaleScope.bind("en-US"),
+    ],
+    // May change for each first instance creation.
+    seed: { currentUserId: seed.currentUserId },
+  });
+
+  return getProfile();
+});
+```
+
+If a dependency should only be used for one branch, declare it with `bunja.will`
+unconditionally, then branch on whether to call the returned thunk.
+
+#### Conditional dependencies
+
+Use `bunja.will` when a bunja may depend on another bunja only for a selected
+branch. `bunja.will` declares a possible dependency and returns a thunk. Only a
+called thunk becomes an active dependency and is mounted.
+
+The thunk may only be called during the same bunja initialization function that
+created it.
+
+```ts
+const resourceA = bunja(() => {
+  const { send } = bunja.use(websocketBunja);
+  bunja.effect(() => {
+    send("subscribe-a");
+    return () => send("unsubscribe-a");
+  });
+});
+
+const resourceB = bunja(() => {
+  const { send } = bunja.use(websocketBunja);
+  bunja.effect(() => {
+    send("subscribe-b");
+    return () => send("unsubscribe-b");
+  });
+});
+
+const selectedResourceBunja = bunja(() => {
+  const selected = bunja.use(SelectedResourceScope);
+  const useA = bunja.will(resourceA);
+  const useB = bunja.will(resourceB);
+
+  return selected === "a" ? useA() : useB();
+});
+```
+
+When a `bunja.will` thunk is called, the selected dependency becomes part of the
+current bunja instance. If that selected dependency resolves to a different
+instance because of scope values, the current bunja also resolves to a different
+instance.
+
+A declared but uncalled `bunja.will` dependency has no effect on the current
+bunja instance.
+
+#### Prebaking the dependency graph
+
+During normal `store.get` and `useBunja`, only the selected `bunja.will` branch
+is baked. If a declared `bunja.will` dependency is not called, that dependency's
+own dependencies may still be unknown. `store.prebake` can be used by devtools
+or debugging code to visit those declared dependencies and fill in the graph.
+
+Prebaking runs bunja init functions in a dry graph-collection mode. It does not
+create ref-counted bunja instances, it does not mount dependencies, and it does
+not run `bunja.effect` callbacks.
+
+`store.prebake` does not accept a seed for the root bunja. Dry-run values use
+each bunja's declared default seed, including dependencies reached through
+seeded refs. Keep external side effects inside `bunja.effect` so prebaking stays
+safe.
+
+```ts
+const result = store.prebake(selectedResourceBunja, readScope);
+
+result.relatedBunjas;
+result.requiredScopes;
+```
+
+The normal `store.get` and `useBunja` paths do not prebake automatically. They
+still mount only the active `bunja.will` branch.
+
 ### Dependency injection using Scope
 
 You can use a bunja for local state management.\
@@ -239,6 +364,11 @@ const UrlContext = createContext("https://example.com/");
 const UrlScope = createScopeFromContext(UrlContext);
 ```
 
+When using React 19, Bunja reads scope contexts lazily with `React.use`, so only
+the contexts needed by the active branch are read. With React 18, Bunja must
+read all bound contexts before resolving the bunja because `useContext` cannot
+be called conditionally. In React 18, call `bindScope` before rendering.
+
 #### Injecting dependencies directly into the scope
 
 You might want to use a bunja directly within a React component where the values
@@ -260,15 +390,15 @@ function MyComponent() {
 
 ##### Doing the same thing inside a bunja
 
-You can use `bunja.fork` to inject scope values from within a bunja
-initialization function.
+You can pass scope value pairs as the second argument to `bunja.use` to override
+scope values from within a bunja initialization function.
 
 ```ts
 const myBunja = bunja(() => {
-  const fooData = bunja.fork(fetchBunja, [
+  const fooData = bunja.use(fetchBunja, [
     UrlScope.bind("https://example.com/foo"),
   ]);
-  const barData = bunja.fork(fetchBunja, [
+  const barData = bunja.use(fetchBunja, [
     UrlScope.bind("https://example.com/bar"),
   ]);
 

--- a/bunja/bunja.ts
+++ b/bunja/bunja.ts
@@ -3,18 +3,21 @@
 const __DEV__ = process.env.NODE_ENV !== "production";
 
 export interface BunjaFn {
-  <T>(init: () => T): Bunja<T, NoSeed>;
+  <T>(init: () => T): Bunja<T, undefined>;
   withSeed: BunjaWithSeedFn;
   use: BunjaUseFn;
   will: BunjaWillFn;
   effect: BunjaEffectFn;
 }
 export const bunja: BunjaFn = bunjaFn;
-function bunjaFn<T>(init: () => T): Bunja<T, NoSeed> {
-  return new Bunja(() => init(), NO_SEED);
+function bunjaFn<T>(init: () => T): Bunja<T, undefined> {
+  return new Bunja(() => init(), undefined);
 }
-const NO_SEED = Symbol("bunja.noSeed");
-export type NoSeed = typeof NO_SEED;
+
+export type BunjaWithSeedFn = <Seed, T>(
+  defaultSeed: Seed,
+  init: (seed: Seed) => T,
+) => Bunja<T, Seed>;
 bunjaFn.withSeed = function withSeed<Seed, T>(
   defaultSeed: Seed,
   init: (seed: Seed) => T,
@@ -43,22 +46,7 @@ bunjaFn.effect =
   ((callback: BunjaEffectCallback) =>
     getCurrentFrame("`bunja.effect`").effect(callback)) as BunjaEffectFn;
 
-export type BunjaWithSeedFn = <Seed, T>(
-  defaultSeed: Seed,
-  init: (seed: Seed) => T,
-) => Bunja<T, Seed>;
 export type ScopeValuePairs = ScopeValuePair<any>[];
-type BunjaRefBase<T, Seed> = {
-  bunja: Bunja<T, Seed>;
-  with?: ScopeValuePairs;
-};
-export type BunjaGetRef<T, Seed = NoSeed> =
-  & BunjaRefBase<T, Seed>
-  & ([Seed] extends [NoSeed] ? { seed?: never } : { seed?: Seed });
-export type BunjaRef<T, Seed = NoSeed> = BunjaGetRef<T, Seed>;
-type BunjaPrebakeRef<T, Seed = NoSeed> = BunjaRefBase<T, Seed> & {
-  seed?: never;
-};
 export interface BunjaUseFn {
   <T>(dep: Scope<T>): T;
   <T, Seed>(dep: Bunja<T, Seed>): T;
@@ -75,6 +63,18 @@ export interface BunjaWillFn {
 }
 export type BunjaEffectFn = (callback: BunjaEffectCallback) => void;
 export type BunjaEffectCallback = () => (() => void) | void;
+
+export interface BunjaRef<T, Seed = undefined> extends BunjaRefBase<T, Seed> {
+  seed?: [Seed] extends [undefined] ? never : Seed;
+}
+export type BunjaGetRef<T, Seed = undefined> = BunjaRef<T, Seed>;
+export interface BunjaPrebakeRef<T, Seed> extends BunjaRefBase<T, Seed> {
+  seed?: never;
+}
+interface BunjaRefBase<T, Seed> {
+  bunja: Bunja<T, Seed>;
+  with?: ScopeValuePairs;
+}
 
 export function createScope<T>(hash?: HashFn<T>): Scope<T> {
   return new Scope(hash);
@@ -891,7 +891,7 @@ export function delayUnmount(
   };
 }
 
-export class Bunja<T, Seed = NoSeed> {
+export class Bunja<T, Seed = undefined> {
   private static counter: number = 0;
   readonly id: string = String(Bunja.counter++);
   debugLabel: string = "";

--- a/bunja/bunja.ts
+++ b/bunja/bunja.ts
@@ -251,11 +251,8 @@ function getBoundScopeSet(
 function getScopeInstances(
   scopes: Scope<unknown>[],
   scopeInstanceMap: ScopeInstanceMap,
-  excludeScopes: Set<Scope<unknown>> = new Set(),
 ): ScopeInstance[] {
-  return scopes
-    .filter((scope) => !excludeScopes.has(scope))
-    .map((scope) => scopeInstanceMap.get(scope)!);
+  return scopes.map((scope) => scopeInstanceMap.get(scope)!);
 }
 
 function dedupeScopeInstances(
@@ -331,6 +328,7 @@ export class BunjaStore {
       readScope,
       new Set(),
       bunjaRef.seed,
+      true,
     );
     const result: BunjaStoreGetResult<T> = {
       value: resolved.value,
@@ -366,6 +364,7 @@ export class BunjaStore {
     readScope: ReadScope,
     inProgressBunjas: Set<AnyBunja>,
     seed: Seed = bunjaRef.bunja.defaultSeed,
+    includeBoundScopeDeps: boolean = false,
   ): ResolvedBunja<T> {
     const { bunja } = bunjaRef;
     if (inProgressBunjas.has(bunja)) {
@@ -382,6 +381,7 @@ export class BunjaStore {
           resolvedReadScope,
           inProgressBunjas,
           seed,
+          includeBoundScopeDeps,
         );
       }
       const scopeInstanceMap = this.#resolveScopeInstanceMap(
@@ -394,9 +394,10 @@ export class BunjaStore {
         scopeInstanceMap,
       );
       const directDeps = getScopeInstances(
-        bunja.requiredScopes,
+        includeBoundScopeDeps
+          ? bunja.requiredScopes
+          : bunja.requiredScopes.filter((scope) => !boundScopes.has(scope)),
         scopeInstanceMap,
-        boundScopes,
       );
       const baseId = bunja.calcBaseInstanceId(scopeInstanceMap);
       const bucket = this.#bunjaBuckets.get(baseId);
@@ -433,6 +434,7 @@ export class BunjaStore {
         resolvedReadScope,
         inProgressBunjas,
         seed,
+        includeBoundScopeDeps,
         scopeInstanceMap,
       );
     } finally {
@@ -444,6 +446,7 @@ export class BunjaStore {
     readScope: ReadScope,
     inProgressBunjas: Set<AnyBunja>,
     seed: Seed,
+    includeBoundScopeDeps: boolean,
     initialScopeInstanceMap: ScopeInstanceMap = new Map(),
   ): ResolvedBunja<T> {
     const { bunja } = bunjaRef;
@@ -475,9 +478,10 @@ export class BunjaStore {
           frame.scopeInstanceMap,
         );
         const directDeps = getScopeInstances(
-          bunja.requiredScopes,
+          includeBoundScopeDeps
+            ? bunja.requiredScopes
+            : bunja.requiredScopes.filter((scope) => !boundScopes.has(scope)),
           frame.scopeInstanceMap,
-          boundScopes,
         );
         const baseId = bunja.calcBaseInstanceId(frame.scopeInstanceMap);
         const id = bunja.calcInstanceId(

--- a/bunja/bunja.ts
+++ b/bunja/bunja.ts
@@ -3,24 +3,76 @@
 const __DEV__ = process.env.NODE_ENV !== "production";
 
 export interface BunjaFn {
-  <T>(init: () => T): Bunja<T>;
+  <T>(init: () => T): Bunja<T, NoSeed>;
+  withSeed: BunjaWithSeedFn;
   use: BunjaUseFn;
-  fork: BunjaForkFn;
+  will: BunjaWillFn;
   effect: BunjaEffectFn;
 }
 export const bunja: BunjaFn = bunjaFn;
-function bunjaFn<T>(init: () => T): Bunja<T> {
-  return new Bunja(init);
+function bunjaFn<T>(init: () => T): Bunja<T, NoSeed> {
+  return new Bunja(() => init(), NO_SEED);
 }
-bunjaFn.use = invalidUse as BunjaUseFn;
-bunjaFn.fork = invalidFork as BunjaForkFn;
-bunjaFn.effect = invalidEffect as BunjaEffectFn;
+const NO_SEED = Symbol("bunja.noSeed");
+export type NoSeed = typeof NO_SEED;
+bunjaFn.withSeed = function withSeed<Seed, T>(
+  defaultSeed: Seed,
+  init: (seed: Seed) => T,
+): Bunja<T, Seed> {
+  return new Bunja(init, defaultSeed);
+};
+bunjaFn.use =
+  ((dep: unknown, scopeValuePairs?: ScopeValuePairs) =>
+    (getCurrentFrame("`bunja.use`").use as (
+      dep: unknown,
+      scopeValuePairs?: ScopeValuePairs,
+    ) => unknown)(
+      dep,
+      scopeValuePairs,
+    )) as BunjaUseFn;
+bunjaFn.will =
+  ((dep: unknown, scopeValuePairs?: ScopeValuePairs) =>
+    (getCurrentFrame("`bunja.will`").will as (
+      dep: unknown,
+      scopeValuePairs?: ScopeValuePairs,
+    ) => unknown)(
+      dep,
+      scopeValuePairs,
+    )) as BunjaWillFn;
+bunjaFn.effect =
+  ((callback: BunjaEffectCallback) =>
+    getCurrentFrame("`bunja.effect`").effect(callback)) as BunjaEffectFn;
 
-export type BunjaUseFn = <T>(dep: Dep<T>) => T;
-export type BunjaForkFn = <T>(
-  bunja: Bunja<T>,
-  scopeValuePairs: ScopeValuePair<any>[],
-) => T;
+export type BunjaWithSeedFn = <Seed, T>(
+  defaultSeed: Seed,
+  init: (seed: Seed) => T,
+) => Bunja<T, Seed>;
+export type ScopeValuePairs = ScopeValuePair<any>[];
+type BunjaRefBase<T, Seed> = {
+  bunja: Bunja<T, Seed>;
+  with?: ScopeValuePairs;
+};
+export type BunjaGetRef<T, Seed = NoSeed> =
+  & BunjaRefBase<T, Seed>
+  & ([Seed] extends [NoSeed] ? { seed?: never } : { seed?: Seed });
+export type BunjaRef<T, Seed = NoSeed> = BunjaGetRef<T, Seed>;
+type BunjaPrebakeRef<T, Seed = NoSeed> = BunjaRefBase<T, Seed> & {
+  seed?: never;
+};
+export interface BunjaUseFn {
+  <T>(dep: Scope<T>): T;
+  <T, Seed>(dep: Bunja<T, Seed>): T;
+  <T, Seed>(bunja: Bunja<T, Seed>, scopeValuePairs: ScopeValuePairs): T;
+  <T, Seed>(ref: BunjaRef<T, Seed>): T;
+}
+export interface BunjaWillFn {
+  <T, Seed>(dep: Bunja<T, Seed>): () => T;
+  <T, Seed>(
+    bunja: Bunja<T, Seed>,
+    scopeValuePairs: ScopeValuePairs,
+  ): () => T;
+  <T, Seed>(ref: BunjaRef<T, Seed>): () => T;
+}
 export type BunjaEffectFn = (callback: BunjaEffectCallback) => void;
 export type BunjaEffectCallback = () => (() => void) | void;
 
@@ -38,32 +90,35 @@ export function createBunjaStore(config?: CreateBunjaStoreConfig): BunjaStore {
   return store;
 }
 
-export type Dep<T> = Bunja<T> | Scope<T>;
+export type Dep<T> = Bunja<T, any> | Scope<T>;
 
-function invalidUse() {
-  throw new Error(
-    "`bunja.use` can only be used inside a bunja init function.",
-  );
-}
-function invalidFork() {
-  throw new Error(
-    "`bunja.fork` can only be used inside a bunja init function.",
-  );
-}
-function invalidEffect() {
-  throw new Error(
-    "`bunja.effect` can only be used inside a bunja init function.",
-  );
-}
-
-interface BunjaStoreGetContext {
-  bunjaInstance: BunjaInstance;
-  bunjaInstanceMap: BunjaInstanceMap;
-  scopeInstanceMap: ScopeInstanceMap;
-}
-
-type BunjaInstanceMap = Map<Bunja<unknown>, BunjaInstance>;
+type AnyBunja = Bunja<any, any>;
 type ScopeInstanceMap = Map<Scope<unknown>, ScopeInstance>;
+type BunjaDependencyEdge = "required" | "optional";
+
+interface BunjaFrame {
+  use: BunjaUseFn;
+  will: BunjaWillFn;
+  effect: BunjaEffectFn;
+}
+
+const frameStack: BunjaFrame[] = [];
+function getCurrentFrame(api: string): BunjaFrame {
+  const frame = frameStack[frameStack.length - 1];
+  if (!frame) {
+    throw new Error(`${api} can only be used inside a bunja init function.`);
+  }
+  return frame;
+}
+
+function runWithFrame<T>(frame: BunjaFrame, fn: () => T): T {
+  frameStack.push(frame);
+  try {
+    return fn();
+  } finally {
+    frameStack.pop();
+  }
+}
 
 interface InternalState {
   bunjas: Record<string, BunjaInstance>;
@@ -71,19 +126,163 @@ interface InternalState {
   instantiating: boolean;
 }
 
-interface BunjaBakingContext {
-  currentBunja: Bunja<unknown>;
+interface BunjaInitFrame extends BunjaFrame {
+  currentBunja: AnyBunja;
+  readScope: ReadScope;
+  scopeInstanceMap: ScopeInstanceMap;
+  inProgressBunjas: Set<AnyBunja>;
+  effects: BunjaEffectCallback[];
+  activeDependencyIds: Set<string>;
+  activeDependencyRecipes: ActiveDependencyRecipe[];
+  activeDependencyMounts: Map<string, () => () => void>;
+  activeDependencyDeps: ScopeInstance[];
+}
+
+interface BunjaPrebakeFrame extends BunjaFrame {
+  currentBunja: AnyBunja;
+  readScope: ReadScope;
+  inProgressBunjas: Set<AnyBunja>;
+}
+
+type AnyNormalizedBunjaRef = NormalizedBunjaRef<any, any>;
+interface NormalizedBunjaRef<T, Seed> {
+  bunja: Bunja<T, Seed>;
+  scopeValuePairs: ScopeValuePairs;
+}
+
+interface NormalizedBunjaRuntimeRef<T, Seed>
+  extends NormalizedBunjaRef<T, Seed> {
+  seed: Seed;
+}
+
+interface ActiveDependencyRecipe {
+  ref: AnyNormalizedBunjaRef;
+  seed: unknown;
+}
+
+interface BunjaInstanceRecipe {
+  activeDependencies: ActiveDependencyRecipe[];
+}
+
+interface ResolvedBunja<T> {
+  value: T;
+  instance: BunjaInstance;
+  mount: () => () => void;
+  deps: ScopeInstance[];
+}
+
+interface ResolvedActiveDependencyRecipe {
+  activeDependencyIds: Set<string>;
+  deps: ScopeInstance[];
 }
 
 export type WrapInstanceFn = <T>(fn: (dispose: () => void) => T) => T;
 const defaultWrapInstanceFn: WrapInstanceFn = (fn) => fn(noop);
 
+function normalizeBunjaRuntimeRef<T, Seed>(
+  bunjaOrRef: Bunja<T, Seed> | BunjaRef<T, Seed>,
+  scopeValuePairs: ScopeValuePairs = [],
+): NormalizedBunjaRuntimeRef<T, Seed> {
+  if (bunjaOrRef instanceof Bunja) {
+    return {
+      bunja: bunjaOrRef,
+      scopeValuePairs,
+      seed: bunjaOrRef.defaultSeed,
+    };
+  }
+  const { bunja, with: refScopeValuePairs = [] } = bunjaOrRef;
+  return {
+    bunja,
+    scopeValuePairs: refScopeValuePairs,
+    seed: "seed" in bunjaOrRef ? (bunjaOrRef.seed as Seed) : bunja.defaultSeed,
+  };
+}
+
+function normalizeBunjaPrebakeRef<T, Seed>(
+  bunjaOrRef: Bunja<T, Seed> | BunjaPrebakeRef<T, Seed>,
+): NormalizedBunjaRef<T, Seed> {
+  if (bunjaOrRef instanceof Bunja) {
+    return {
+      bunja: bunjaOrRef,
+      scopeValuePairs: [],
+    };
+  }
+  if ("seed" in bunjaOrRef) {
+    throw new Error("A bunja seed cannot be provided to `store.prebake`.");
+  }
+  const { bunja, with: refScopeValuePairs = [] } = bunjaOrRef;
+  return {
+    bunja,
+    scopeValuePairs: refScopeValuePairs,
+  };
+}
+
+function toBunjaGraphRef<T, Seed>(
+  bunjaRef: NormalizedBunjaRef<T, Seed>,
+): NormalizedBunjaRef<T, Seed> {
+  return {
+    bunja: bunjaRef.bunja,
+    scopeValuePairs: bunjaRef.scopeValuePairs,
+  };
+}
+
+function isBunjaRef(value: unknown): value is BunjaRef<any, any> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "bunja" in value &&
+    (value as { bunja: unknown }).bunja instanceof Bunja
+  );
+}
+
+function getBoundScopeSet(
+  scopeValuePairs: ScopeValuePairs,
+): Set<Scope<unknown>> {
+  return new Set(
+    scopeValuePairs.map(([scope]) => scope as Scope<unknown>),
+  );
+}
+
+function getScopeInstances(
+  scopes: Scope<unknown>[],
+  scopeInstanceMap: ScopeInstanceMap,
+  excludeScopes: Set<Scope<unknown>> = new Set(),
+): ScopeInstance[] {
+  return scopes
+    .filter((scope) => !excludeScopes.has(scope))
+    .map((scope) => scopeInstanceMap.get(scope)!);
+}
+
+function dedupeScopeInstances(
+  scopeInstances: ScopeInstance[],
+): ScopeInstance[] {
+  const seen = new Set<string>();
+  const result: ScopeInstance[] = [];
+  for (const scopeInstance of scopeInstances) {
+    if (seen.has(scopeInstance.id)) continue;
+    seen.add(scopeInstance.id);
+    result.push(scopeInstance);
+  }
+  return result;
+}
+
+function dedupeBunjas(bunjas: AnyBunja[]): AnyBunja[] {
+  return Array.from(new Set(bunjas));
+}
+
+function addUniqueBunjaRef(
+  refs: AnyNormalizedBunjaRef[],
+  ref: AnyNormalizedBunjaRef,
+): void {
+  if (!refs.includes(ref)) refs.push(ref);
+}
+
 export class BunjaStore {
   private static counter: number = 0;
   readonly id: string = String(BunjaStore.counter++);
   #bunjas: Record<string, BunjaInstance> = {};
+  #bunjaBuckets: Map<string, Set<string>> = new Map();
   #scopes: Map<Scope<unknown>, Map<unknown, ScopeInstance>> = new Map();
-  #bakingContext: BunjaBakingContext | undefined;
   wrapInstance: WrapInstanceFn = defaultWrapInstanceFn;
   constructor() {
     if (__DEV__) devtoolsGlobalHook.emit("storeCreated", { storeId: this.id });
@@ -94,7 +293,7 @@ export class BunjaStore {
         bunjas: this.#bunjas,
         scopes: this.#scopes,
         get instantiating() {
-          return bunja.use != invalidUse;
+          return frameStack.length > 0;
         },
       };
     }
@@ -102,156 +301,484 @@ export class BunjaStore {
   }
   dispose(): void {
     for (const instance of Object.values(this.#bunjas)) instance.dispose();
-    for (const instanceMap of Object.values(this.#scopes)) {
+    for (const instanceMap of this.#scopes.values()) {
       for (const instance of instanceMap.values()) instance.dispose();
     }
     this.#bunjas = {};
+    this.#bunjaBuckets = new Map();
     this.#scopes = new Map();
     if (__DEV__) devtoolsGlobalHook.emit("storeDisposed", { storeId: this.id });
   }
-  get<T>(bunja: Bunja<T>, readScope: ReadScope): BunjaStoreGetResult<T> {
-    const originalUse = bunjaFn.use;
+  get<T, Seed>(
+    bunjaOrRef: Bunja<T, Seed> | BunjaGetRef<T, Seed>,
+    readScope: ReadScope,
+  ): BunjaStoreGetResult<T> {
+    const bunjaRef = normalizeBunjaRuntimeRef(bunjaOrRef);
+    const resolved = this.#resolveBunjaRef(
+      toBunjaGraphRef(bunjaRef),
+      readScope,
+      new Set(),
+      bunjaRef.seed,
+    );
+    const result: BunjaStoreGetResult<T> = {
+      value: resolved.value,
+      mount: resolved.mount,
+      deps: resolved.deps.map(({ value }) => value),
+    };
+    if (__DEV__) {
+      result.bunjaInstance = resolved.instance;
+      devtoolsGlobalHook.emit("getCalled", {
+        storeId: this.id,
+        bunjaInstanceId: resolved.instance.id,
+      });
+    }
+    return result;
+  }
+  prebake<T, Seed>(
+    bunjaOrRef: Bunja<T, Seed> | BunjaPrebakeRef<T, Seed>,
+    readScope: ReadScope,
+  ): BunjaStorePrebakeResult<T> {
+    const bunjaRef = normalizeBunjaPrebakeRef(bunjaOrRef);
+    const value = this.#prebakeBunjaRef(
+      bunjaRef,
+      readScope,
+      new Set(),
+    );
+    return {
+      value,
+      relatedBunjas: bunjaRef.bunja.relatedBunjas,
+      requiredScopes: bunjaRef.bunja.requiredScopes,
+    };
+  }
+  #resolveBunjaRef<T, Seed>(
+    bunjaRef: NormalizedBunjaRef<T, Seed>,
+    readScope: ReadScope,
+    inProgressBunjas: Set<AnyBunja>,
+    seed: Seed = bunjaRef.bunja.defaultSeed,
+  ): ResolvedBunja<T> {
+    const { bunja } = bunjaRef;
+    if (inProgressBunjas.has(bunja)) {
+      throw new Error("Circular bunja dependency detected.");
+    }
+    const resolvedReadScope = bunjaRef.scopeValuePairs.length > 0
+      ? createReadScopeFn(bunjaRef.scopeValuePairs, readScope)
+      : readScope;
+    inProgressBunjas.add(bunja);
     try {
-      const { bunjaInstance, bunjaInstanceMap, scopeInstanceMap } = bunja.baked
-        ? this.#getBaked(bunja, readScope)
-        : this.#getUnbaked(bunja, readScope);
-      const result: BunjaStoreGetResult<T> = {
-        value: bunjaInstance.value as T,
-        mount: () => {
-          bunjaInstanceMap.forEach((instance) => instance.add());
-          bunjaInstance.add();
-          scopeInstanceMap.forEach((instance) => instance.add());
-          const unmount = () => {
-            bunjaInstanceMap.forEach((instance) => instance.sub());
-            bunjaInstance.sub();
-            scopeInstanceMap.forEach((instance) => instance.sub());
-          };
-          return unmount;
-        },
-        deps: Array.from(scopeInstanceMap.values()).map(({ value }) => value),
-      };
-      if (__DEV__) {
-        result.bunjaInstance = bunjaInstance;
-        devtoolsGlobalHook.emit("getCalled", {
-          storeId: this.id,
-          bunjaInstanceId: bunjaInstance.id,
-        });
+      if (!bunja.baked) {
+        return this.#createResolvedBunja(
+          bunjaRef,
+          resolvedReadScope,
+          inProgressBunjas,
+          seed,
+        );
       }
-      return result;
+      const scopeInstanceMap = this.#resolveScopeInstanceMap(
+        bunja,
+        resolvedReadScope,
+      );
+      const boundScopes = getBoundScopeSet(bunjaRef.scopeValuePairs);
+      const scopeInstances = getScopeInstances(
+        bunja.requiredScopes,
+        scopeInstanceMap,
+      );
+      const directDeps = getScopeInstances(
+        bunja.requiredScopes,
+        scopeInstanceMap,
+        boundScopes,
+      );
+      const baseId = bunja.calcBaseInstanceId(scopeInstanceMap);
+      const bucket = this.#bunjaBuckets.get(baseId);
+      if (bucket) {
+        for (const candidateId of Array.from(bucket)) {
+          const candidate = this.#bunjas[candidateId];
+          if (!candidate) {
+            bucket.delete(candidateId);
+            continue;
+          }
+          const activeDeps = this.#resolveActiveDependencyRecipe(
+            candidate.recipe,
+            resolvedReadScope,
+            inProgressBunjas,
+          );
+          const currentId = bunja.calcInstanceId(
+            scopeInstanceMap,
+            activeDeps.activeDependencyIds,
+          );
+          const instance = currentId === candidate.id
+            ? candidate
+            : this.#bunjas[currentId];
+          if (!instance) continue;
+          return this.#toResolvedBunja(
+            instance,
+            scopeInstances,
+            directDeps,
+            activeDeps.deps,
+          );
+        }
+      }
+      return this.#createResolvedBunja(
+        bunjaRef,
+        resolvedReadScope,
+        inProgressBunjas,
+        seed,
+        scopeInstanceMap,
+      );
     } finally {
-      bunjaFn.use = originalUse;
+      inProgressBunjas.delete(bunja);
     }
   }
-  #getBaked<T>(bunja: Bunja<T>, readScope: ReadScope): BunjaStoreGetContext {
-    const scopeInstanceMap = new Map(
-      bunja.relatedScopes.map((scope) => [
+  #createResolvedBunja<T, Seed>(
+    bunjaRef: NormalizedBunjaRef<T, Seed>,
+    readScope: ReadScope,
+    inProgressBunjas: Set<AnyBunja>,
+    seed: Seed,
+    initialScopeInstanceMap: ScopeInstanceMap = new Map(),
+  ): ResolvedBunja<T> {
+    const { bunja } = bunjaRef;
+    return this.wrapInstance((dispose) => {
+      let instanceCreated = false;
+      let disposed = false;
+      const disposeOnce = () => {
+        if (disposed) return;
+        disposed = true;
+        dispose();
+      };
+      try {
+        const frame = this.#createInitFrame(
+          bunja,
+          readScope,
+          initialScopeInstanceMap,
+          inProgressBunjas,
+        );
+        const value = runWithFrame(frame, () => bunja.init(seed));
+        if (!bunja.baked) bunja.bake();
+        this.#ensureRequiredScopeInstances(
+          bunja,
+          frame.scopeInstanceMap,
+          readScope,
+        );
+        const boundScopes = getBoundScopeSet(bunjaRef.scopeValuePairs);
+        const scopeInstances = getScopeInstances(
+          bunja.requiredScopes,
+          frame.scopeInstanceMap,
+        );
+        const directDeps = getScopeInstances(
+          bunja.requiredScopes,
+          frame.scopeInstanceMap,
+          boundScopes,
+        );
+        const baseId = bunja.calcBaseInstanceId(frame.scopeInstanceMap);
+        const id = bunja.calcInstanceId(
+          frame.scopeInstanceMap,
+          frame.activeDependencyIds,
+        );
+        const existing = this.#bunjas[id];
+        if (existing) {
+          disposeOnce();
+          return this.#toResolvedBunja(
+            existing,
+            scopeInstances,
+            directDeps,
+            frame.activeDependencyDeps,
+          );
+        }
+        const instance = this.#createBunjaInstance(
+          id,
+          baseId,
+          value,
+          Array.from(frame.activeDependencyMounts.values()),
+          frame.effects,
+          { activeDependencies: frame.activeDependencyRecipes },
+          dispose,
+        );
+        instanceCreated = true;
+        return this.#toResolvedBunja(
+          instance,
+          scopeInstances,
+          directDeps,
+          frame.activeDependencyDeps,
+        );
+      } finally {
+        if (!instanceCreated) disposeOnce();
+      }
+    });
+  }
+  #toResolvedBunja<T>(
+    instance: BunjaInstance,
+    scopeInstances: ScopeInstance[],
+    directDeps: ScopeInstance[],
+    activeDependencyDeps: ScopeInstance[],
+  ): ResolvedBunja<T> {
+    const deps = dedupeScopeInstances([
+      ...directDeps,
+      ...activeDependencyDeps,
+    ]);
+    return {
+      value: instance.value as T,
+      instance,
+      deps,
+      mount: () => {
+        for (const scopeInstance of scopeInstances) scopeInstance.add();
+        instance.add();
+        return () => {
+          instance.sub();
+          for (const scopeInstance of scopeInstances) scopeInstance.sub();
+        };
+      },
+    };
+  }
+  #createInitFrame(
+    currentBunja: AnyBunja,
+    readScope: ReadScope,
+    scopeInstanceMap: ScopeInstanceMap,
+    inProgressBunjas: Set<AnyBunja>,
+  ): BunjaInitFrame {
+    const frame = {
+      currentBunja,
+      readScope,
+      scopeInstanceMap,
+      inProgressBunjas,
+      effects: [] as BunjaEffectCallback[],
+      activeDependencyIds: new Set<string>(),
+      activeDependencyRecipes: [] as ActiveDependencyRecipe[],
+      activeDependencyMounts: new Map<string, () => () => void>(),
+      activeDependencyDeps: [] as ScopeInstance[],
+      use: ((dep: unknown, scopeValuePairs?: ScopeValuePairs) => {
+        if (dep instanceof Scope) {
+          return this.#useScopeInFrame(frame, dep as Scope<unknown>);
+        }
+        if (dep instanceof Bunja || isBunjaRef(dep)) {
+          return this.#useBunjaDependencyInFrame(
+            frame,
+            normalizeBunjaRuntimeRef(dep, scopeValuePairs),
+            "required",
+          );
+        }
+        throw new Error("`bunja.use` can only be used with Bunja or Scope.");
+      }) as BunjaUseFn,
+      will: ((dep: unknown, scopeValuePairs?: ScopeValuePairs) => {
+        if (!(dep instanceof Bunja || isBunjaRef(dep))) {
+          throw new Error("`bunja.will` can only be used with Bunja.");
+        }
+        const bunjaRef = normalizeBunjaRuntimeRef(dep, scopeValuePairs);
+        currentBunja.addOptionalBunjaRef(toBunjaGraphRef(bunjaRef));
+        return () => {
+          if (frameStack[frameStack.length - 1] !== frame) {
+            throw new Error(
+              "A thunk returned by `bunja.will` can only be called inside the same bunja init function.",
+            );
+          }
+          return this.#useBunjaDependencyInFrame(
+            frame,
+            bunjaRef,
+            "optional",
+          );
+        };
+      }) as BunjaWillFn,
+      effect: ((callback: BunjaEffectCallback) => {
+        frame.effects.push(callback);
+      }) as BunjaEffectFn,
+    } satisfies BunjaInitFrame;
+    return frame;
+  }
+  #useScopeInFrame<T>(frame: BunjaInitFrame, scope: Scope<T>): T {
+    if (!frame.currentBunja.baked) {
+      frame.currentBunja.addScope(scope as Scope<unknown>);
+    }
+    let scopeInstance = frame.scopeInstanceMap.get(scope as Scope<unknown>);
+    if (!scopeInstance) {
+      if (frame.currentBunja.baked) {
+        throw new Error(
+          "`bunja.use(scope)` cannot introduce a new scope after the bunja is baked.",
+        );
+      }
+      scopeInstance = this.#getScopeInstance(
+        scope as Scope<unknown>,
+        frame.readScope(scope),
+      );
+      frame.scopeInstanceMap.set(scope as Scope<unknown>, scopeInstance);
+    }
+    return scopeInstance.value as T;
+  }
+  #useBunjaDependencyInFrame<T, Seed>(
+    frame: BunjaInitFrame,
+    bunjaRef: NormalizedBunjaRuntimeRef<T, Seed>,
+    edge: BunjaDependencyEdge,
+  ): T {
+    const graphRef = toBunjaGraphRef(bunjaRef);
+    if (edge === "optional" || graphRef.scopeValuePairs.length > 0) {
+      frame.currentBunja.addOptionalBunjaRef(graphRef);
+    } else if (edge === "required") {
+      frame.currentBunja.addRequiredBunjaRef(graphRef);
+    }
+    const resolved = this.#resolveBunjaRef(
+      graphRef,
+      frame.readScope,
+      frame.inProgressBunjas,
+      bunjaRef.seed,
+    );
+    frame.activeDependencyIds.add(resolved.instance.id);
+    frame.activeDependencyRecipes.push({
+      ref: graphRef,
+      seed: bunjaRef.seed,
+    });
+    if (!frame.activeDependencyMounts.has(resolved.instance.id)) {
+      frame.activeDependencyMounts.set(resolved.instance.id, resolved.mount);
+    }
+    frame.activeDependencyDeps.push(...resolved.deps);
+    return resolved.value;
+  }
+  #resolveActiveDependencyRecipe(
+    recipe: BunjaInstanceRecipe,
+    readScope: ReadScope,
+    inProgressBunjas: Set<AnyBunja>,
+  ): ResolvedActiveDependencyRecipe {
+    const activeDependencyIds = new Set<string>();
+    const deps: ScopeInstance[] = [];
+    for (const { ref, seed } of recipe.activeDependencies) {
+      const resolved = this.#resolveBunjaRef(
+        ref,
+        readScope,
+        inProgressBunjas,
+        seed,
+      );
+      activeDependencyIds.add(resolved.instance.id);
+      deps.push(...resolved.deps);
+    }
+    return {
+      activeDependencyIds,
+      deps: dedupeScopeInstances(deps),
+    };
+  }
+  #prebakeBunjaRef<T, Seed>(
+    bunjaRef: NormalizedBunjaRef<T, Seed>,
+    readScope: ReadScope,
+    inProgressBunjas: Set<AnyBunja>,
+  ): T {
+    const { bunja } = bunjaRef;
+    if (inProgressBunjas.has(bunja)) {
+      throw new Error("Circular bunja dependency detected.");
+    }
+    const resolvedReadScope = bunjaRef.scopeValuePairs.length > 0
+      ? createReadScopeFn(bunjaRef.scopeValuePairs, readScope)
+      : readScope;
+    inProgressBunjas.add(bunja);
+    try {
+      return this.wrapInstance((dispose) => {
+        try {
+          const frame = this.#createPrebakeFrame(
+            bunja,
+            resolvedReadScope,
+            inProgressBunjas,
+          );
+          const value = runWithFrame(
+            frame,
+            () => bunja.init(bunja.defaultSeed),
+          );
+          if (!bunja.baked) bunja.bake();
+          for (
+            const ref of [
+              ...bunja.requiredBunjaRefs,
+              ...bunja.optionalBunjaRefs,
+            ]
+          ) this.#prebakeBunjaRef(ref, resolvedReadScope, inProgressBunjas);
+          return value;
+        } finally {
+          dispose();
+        }
+      });
+    } finally {
+      inProgressBunjas.delete(bunja);
+    }
+  }
+  #createPrebakeFrame(
+    currentBunja: AnyBunja,
+    readScope: ReadScope,
+    inProgressBunjas: Set<AnyBunja>,
+  ): BunjaPrebakeFrame {
+    const frame = {
+      currentBunja,
+      readScope,
+      inProgressBunjas,
+      use: ((dep: unknown, scopeValuePairs?: ScopeValuePairs) => {
+        if (dep instanceof Scope) {
+          if (!currentBunja.baked) {
+            currentBunja.addScope(dep as Scope<unknown>);
+          }
+          return readScope(dep as Scope<unknown>);
+        }
+        if (dep instanceof Bunja || isBunjaRef(dep)) {
+          const bunjaRef = normalizeBunjaRuntimeRef(dep, scopeValuePairs);
+          return this.#prebakeBunjaDependencyInFrame(
+            frame,
+            toBunjaGraphRef(bunjaRef),
+            "required",
+          );
+        }
+        throw new Error("`bunja.use` can only be used with Bunja or Scope.");
+      }) as BunjaUseFn,
+      will: ((dep: unknown, scopeValuePairs?: ScopeValuePairs) => {
+        if (!(dep instanceof Bunja || isBunjaRef(dep))) {
+          throw new Error("`bunja.will` can only be used with Bunja.");
+        }
+        const bunjaRef = toBunjaGraphRef(
+          normalizeBunjaRuntimeRef(dep, scopeValuePairs),
+        );
+        currentBunja.addOptionalBunjaRef(bunjaRef);
+        const value = this.#prebakeBunjaRef(
+          bunjaRef,
+          readScope,
+          inProgressBunjas,
+        );
+        return () => {
+          if (frameStack[frameStack.length - 1] !== frame) {
+            throw new Error(
+              "A thunk returned by `bunja.will` can only be called inside the same bunja init function.",
+            );
+          }
+          return value;
+        };
+      }) as BunjaWillFn,
+      effect: noop,
+    } satisfies BunjaPrebakeFrame;
+    return frame;
+  }
+  #prebakeBunjaDependencyInFrame<T, Seed>(
+    frame: BunjaPrebakeFrame,
+    bunjaRef: NormalizedBunjaRef<T, Seed>,
+    edge: BunjaDependencyEdge,
+  ): T {
+    if (edge === "optional" || bunjaRef.scopeValuePairs.length > 0) {
+      frame.currentBunja.addOptionalBunjaRef(bunjaRef);
+    } else if (edge === "required") {
+      frame.currentBunja.addRequiredBunjaRef(bunjaRef);
+    }
+    return this.#prebakeBunjaRef(
+      bunjaRef,
+      frame.readScope,
+      frame.inProgressBunjas,
+    );
+  }
+  #resolveScopeInstanceMap(
+    bunja: AnyBunja,
+    readScope: ReadScope,
+  ): ScopeInstanceMap {
+    const scopeInstanceMap: ScopeInstanceMap = new Map();
+    this.#ensureRequiredScopeInstances(bunja, scopeInstanceMap, readScope);
+    return scopeInstanceMap;
+  }
+  #ensureRequiredScopeInstances(
+    bunja: AnyBunja,
+    scopeInstanceMap: ScopeInstanceMap,
+    readScope: ReadScope,
+  ): void {
+    for (const scope of bunja.requiredScopes) {
+      if (scopeInstanceMap.has(scope)) continue;
+      scopeInstanceMap.set(
         scope,
         this.#getScopeInstance(scope, readScope(scope)),
-      ]),
-    );
-    const bunjaInstanceMap = new Map();
-    bunjaFn.use = <T>(dep: Dep<T>) => {
-      if (dep instanceof Bunja) {
-        return bunjaInstanceMap.get(dep as Bunja<unknown>)!.value as T;
-      }
-      if (dep instanceof Scope) {
-        return scopeInstanceMap.get(dep as Scope<unknown>)!.value as T;
-      }
-      throw new Error("`bunja.use` can only be used with Bunja or Scope.");
-    };
-    for (const relatedBunja of bunja.relatedBunjas) {
-      bunjaInstanceMap.set(
-        relatedBunja,
-        this.#getBunjaInstance(relatedBunja, scopeInstanceMap),
       );
-    }
-    const bunjaInstance = this.#getBunjaInstance(bunja, scopeInstanceMap);
-    return { bunjaInstance, bunjaInstanceMap, scopeInstanceMap };
-  }
-  #getUnbaked<T>(bunja: Bunja<T>, readScope: ReadScope): BunjaStoreGetContext {
-    const bunjaInstanceMap: BunjaInstanceMap = new Map();
-    const scopeInstanceMap: ScopeInstanceMap = new Map();
-    function getUse<D extends Dep<unknown>, I extends { value: unknown }>(
-      map: Map<D, I>,
-      addDep: (D: D) => void,
-      getInstance: (dep: D) => I,
-    ) {
-      return ((dep) => {
-        const d = dep as D;
-        addDep(d);
-        if (map.has(d)) return map.get(d)!.value as T;
-        const instance = getInstance(d);
-        map.set(d, instance);
-        return instance.value as T;
-      }) as <T>(dep: Dep<T>) => T;
-    }
-    const useScope = getUse(
-      scopeInstanceMap,
-      (dep) => this.#bakingContext!.currentBunja.addScope(dep),
-      (dep) => this.#getScopeInstance(dep, readScope(dep)),
-    );
-    const useBunja = getUse(
-      bunjaInstanceMap,
-      (dep) => this.#bakingContext!.currentBunja.addParent(dep),
-      (dep) => {
-        if (dep.baked) {
-          for (const scope of dep.relatedScopes) useScope(scope);
-        }
-        return this.#getBunjaInstance(dep, scopeInstanceMap);
-      },
-    );
-    bunjaFn.use = <T>(dep: Dep<T>) => {
-      if (dep instanceof Bunja) return useBunja(dep) as T;
-      if (dep instanceof Scope) return useScope(dep) as T;
-      throw new Error("`bunja.use` can only be used with Bunja or Scope.");
-    };
-    const originalBakingContext = this.#bakingContext;
-    try {
-      this.#bakingContext = { currentBunja: bunja };
-      const bunjaInstance = this.#getBunjaInstance(bunja, scopeInstanceMap);
-      return { bunjaInstance, bunjaInstanceMap, scopeInstanceMap };
-    } finally {
-      this.#bakingContext = originalBakingContext;
-    }
-  }
-  #getBunjaInstance<T>(
-    bunja: Bunja<T>,
-    scopeInstanceMap: ScopeInstanceMap,
-  ): BunjaInstance {
-    const originalEffect = bunjaFn.effect;
-    const originalFork = bunjaFn.fork;
-    const prevBunja = this.#bakingContext?.currentBunja;
-    try {
-      const effects: BunjaEffectCallback[] = [];
-      bunjaFn.effect = (callback: BunjaEffectCallback) => {
-        effects.push(callback);
-      };
-      bunjaFn.fork = (b, scopeValuePairs) => {
-        const readScope = createReadScopeFn(scopeValuePairs, bunjaFn.use);
-        const { value, mount } = this.get(b, readScope);
-        bunjaFn.effect(mount);
-        return value;
-      };
-      if (this.#bakingContext) this.#bakingContext.currentBunja = bunja;
-      if (bunja.baked) {
-        const id = bunja.calcInstanceId(scopeInstanceMap);
-        if (id in this.#bunjas) return this.#bunjas[id];
-        return this.wrapInstance((dispose) => {
-          const value = bunja.init();
-          return this.#createBunjaInstance(id, value, effects, dispose);
-        });
-      } else {
-        return this.wrapInstance((dispose) => {
-          const value = bunja.init();
-          bunja.bake();
-          const id = bunja.calcInstanceId(scopeInstanceMap);
-          return this.#createBunjaInstance(id, value, effects, dispose);
-        });
-      }
-    } finally {
-      bunjaFn.effect = originalEffect;
-      bunjaFn.fork = originalFork;
-      if (this.#bakingContext) this.#bakingContext.currentBunja = prevBunja!;
     }
   }
   #getScopeInstance(scope: Scope<unknown>, value: unknown): ScopeInstance {
@@ -275,27 +802,38 @@ export class BunjaStore {
   }
   #createBunjaInstance(
     id: string,
+    baseId: string,
     value: unknown,
+    dependencyMounts: (() => () => void)[],
     effects: BunjaEffectCallback[],
+    recipe: BunjaInstanceRecipe,
     dispose: () => void,
   ): BunjaInstance {
-    const effect = () => {
-      const cleanups = effects
-        .map((effect) => effect())
-        .filter(Boolean) as (() => void)[];
-      return () => cleanups.forEach((cleanup) => cleanup());
-    };
-    const bunjaInstance = new BunjaInstance(id, value, effect, () => {
-      if (__DEV__) {
-        devtoolsGlobalHook.emit("bunjaInstanceUnmounted", {
-          storeId: this.id,
-          bunjaInstanceId: id,
-        });
-      }
-      dispose();
-      delete this.#bunjas[id];
-    });
+    const bunjaInstance = new BunjaInstance(
+      id,
+      baseId,
+      value,
+      dependencyMounts,
+      effects,
+      recipe,
+      () => {
+        if (__DEV__) {
+          devtoolsGlobalHook.emit("bunjaInstanceUnmounted", {
+            storeId: this.id,
+            bunjaInstanceId: id,
+          });
+        }
+        dispose();
+        delete this.#bunjas[id];
+        const bucket = this.#bunjaBuckets.get(baseId);
+        bucket?.delete(id);
+        if (bucket?.size === 0) this.#bunjaBuckets.delete(baseId);
+      },
+    );
     this.#bunjas[id] = bunjaInstance;
+    const bucket = this.#bunjaBuckets.get(baseId) ??
+      this.#bunjaBuckets.set(baseId, new Set()).get(baseId)!;
+    bucket.add(id);
     if (__DEV__) {
       devtoolsGlobalHook.emit("bunjaInstanceMounted", {
         storeId: this.id,
@@ -342,6 +880,12 @@ export interface BunjaStoreGetResult<T> {
   bunjaInstance?: BunjaInstance;
 }
 
+export interface BunjaStorePrebakeResult<T> {
+  value: T;
+  relatedBunjas: Bunja<any, any>[];
+  requiredScopes: Scope<unknown>[];
+}
+
 export function delayUnmount(
   mount: () => () => void,
   ms: number = 0,
@@ -352,12 +896,20 @@ export function delayUnmount(
   };
 }
 
-export class Bunja<T> {
+export class Bunja<T, Seed = NoSeed> {
   private static counter: number = 0;
   readonly id: string = String(Bunja.counter++);
   debugLabel: string = "";
-  #phase: BunjaPhase = { baked: false, parents: new Set(), scopes: new Set() };
-  constructor(public init: () => T) {
+  #phase: BunjaPhase = {
+    baked: false,
+    requiredBunjaRefs: [],
+    optionalBunjaRefs: [],
+    scopes: new Set(),
+  };
+  constructor(
+    public init: (seed: Seed) => T,
+    public defaultSeed: Seed,
+  ) {
     if (__DEV__) {
       devtoolsGlobalHook.bunjas[this.id] = this;
       devtoolsGlobalHook.emit("bunjaCreated", { bunjaId: this.id });
@@ -366,21 +918,44 @@ export class Bunja<T> {
   get baked(): boolean {
     return this.#phase.baked;
   }
-  get parents(): Bunja<unknown>[] {
-    if (this.#phase.baked) return this.#phase.parents;
-    return Array.from(this.#phase.parents);
+  get requiredBunjas(): AnyBunja[] {
+    return dedupeBunjas(
+      this.#phase.requiredBunjaRefs.map(({ bunja }) => bunja),
+    );
   }
-  get relatedBunjas(): Bunja<unknown>[] {
+  get optionalBunjas(): AnyBunja[] {
+    return dedupeBunjas(
+      this.#phase.optionalBunjaRefs.map(({ bunja }) => bunja),
+    );
+  }
+  get requiredBunjaRefs(): AnyNormalizedBunjaRef[] {
+    return this.#phase.requiredBunjaRefs;
+  }
+  get optionalBunjaRefs(): AnyNormalizedBunjaRef[] {
+    return this.#phase.optionalBunjaRefs;
+  }
+  get expandedRequiredBunjas(): AnyBunja[] {
     if (!this.#phase.baked) throw new Error("Bunja is not baked yet.");
-    return this.#phase.relatedBunjas;
+    return this.#phase.expandedRequiredBunjas;
   }
-  get relatedScopes(): Scope<unknown>[] {
+  get relatedBunjas(): AnyBunja[] {
     if (!this.#phase.baked) throw new Error("Bunja is not baked yet.");
-    return this.#phase.relatedScopes;
+    return toposortRelatedBunjas([
+      ...this.requiredBunjas,
+      ...this.optionalBunjas,
+    ]);
   }
-  addParent(bunja: Bunja<unknown>): void {
+  get requiredScopes(): Scope<unknown>[] {
+    if (!this.#phase.baked) throw new Error("Bunja is not baked yet.");
+    return this.#phase.requiredScopes;
+  }
+  addRequiredBunjaRef(ref: AnyNormalizedBunjaRef): void {
     if (this.#phase.baked) return;
-    this.#phase.parents.add(bunja);
+    addUniqueBunjaRef(this.#phase.requiredBunjaRefs, ref);
+  }
+  addOptionalBunjaRef(ref: AnyNormalizedBunjaRef): void {
+    if (this.#phase.baked) return;
+    addUniqueBunjaRef(this.#phase.optionalBunjaRefs, ref);
   }
   addScope(scope: Scope<unknown>): void {
     if (this.#phase.baked) return;
@@ -389,21 +964,39 @@ export class Bunja<T> {
   bake(): void {
     if (this.#phase.baked) throw new Error("Bunja is already baked.");
     const scopes = this.#phase.scopes;
-    const parents = this.parents;
-    const relatedBunjas = toposort(parents);
-    const relatedScopes = Array.from(
-      new Set([
-        ...relatedBunjas.flatMap((bunja) => bunja.relatedScopes),
-        ...scopes,
-      ]),
-    );
-    this.#phase = { baked: true, parents, relatedBunjas, relatedScopes };
+    const requiredBunjaRefs = this.#phase.requiredBunjaRefs;
+    const optionalBunjaRefs = this.#phase.optionalBunjaRefs;
+    const requiredBunjas = this.requiredBunjas;
+    const expandedRequiredBunjas = toposortRequiredBunjas(requiredBunjas);
+    const requiredScopeSet = new Set<Scope<unknown>>();
+    for (const bunja of expandedRequiredBunjas) {
+      for (const scope of bunja.requiredScopes) requiredScopeSet.add(scope);
+    }
+    for (const scope of scopes) requiredScopeSet.add(scope);
+    const requiredScopes = Array.from(requiredScopeSet);
+    this.#phase = {
+      baked: true,
+      requiredBunjaRefs,
+      optionalBunjaRefs,
+      expandedRequiredBunjas,
+      requiredScopes,
+    };
   }
-  calcInstanceId(scopeInstanceMap: Map<Scope<unknown>, ScopeInstance>): string {
-    const scopeInstanceIds = this.relatedScopes.map(
+  calcBaseInstanceId(
+    scopeInstanceMap: Map<Scope<unknown>, ScopeInstance>,
+  ): string {
+    const scopeInstanceIds = this.requiredScopes.map(
       (scope) => scopeInstanceMap.get(scope)!.id,
     );
     return `${this.id}:${scopeInstanceIds.join(",")}`;
+  }
+  calcInstanceId(
+    scopeInstanceMap: Map<Scope<unknown>, ScopeInstance>,
+    activeDependencyIds: Iterable<string> = [],
+  ): string {
+    return `${this.calcBaseInstanceId(scopeInstanceMap)}:${
+      Array.from(activeDependencyIds).join(",")
+    }`;
   }
   toString(): string {
     const { id, debugLabel } = this;
@@ -415,15 +1008,17 @@ type BunjaPhase = BunjaPhaseUnbaked | BunjaPhaseBaked;
 
 interface BunjaPhaseUnbaked {
   readonly baked: false;
-  readonly parents: Set<Bunja<unknown>>;
+  readonly requiredBunjaRefs: AnyNormalizedBunjaRef[];
+  readonly optionalBunjaRefs: AnyNormalizedBunjaRef[];
   readonly scopes: Set<Scope<unknown>>;
 }
 
 interface BunjaPhaseBaked {
   readonly baked: true;
-  readonly parents: Bunja<unknown>[];
-  readonly relatedBunjas: Bunja<unknown>[];
-  readonly relatedScopes: Scope<unknown>[];
+  readonly requiredBunjaRefs: AnyNormalizedBunjaRef[];
+  readonly optionalBunjaRefs: AnyNormalizedBunjaRef[];
+  readonly expandedRequiredBunjas: AnyBunja[];
+  readonly requiredScopes: Scope<unknown>[];
 }
 
 export class Scope<T> {
@@ -468,21 +1063,38 @@ abstract class RefCounter {
 
 class BunjaInstance extends RefCounter {
   #cleanup: (() => void) | undefined;
+  #disposed = false;
   constructor(
     public readonly id: string,
+    public readonly baseId: string,
     public readonly value: unknown,
-    public readonly effect: BunjaEffectCallback,
+    private readonly dependencyMounts: (() => () => void)[],
+    private readonly effects: BunjaEffectCallback[],
+    public readonly recipe: BunjaInstanceRecipe,
     private readonly _dispose: () => void,
   ) {
     super();
   }
   override dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
     this.#cleanup?.();
+    this.#cleanup = undefined;
     this._dispose();
   }
   override add(): void {
-    this.#cleanup ??= this.effect() ?? noop;
+    this.#cleanup ??= this.#mount();
     super.add();
+  }
+  #mount(): () => void {
+    const dependencyCleanups = this.dependencyMounts.map((mount) => mount());
+    const effectCleanups = this.effects
+      .map((effect) => effect())
+      .filter(Boolean) as (() => void)[];
+    return () => {
+      for (const cleanup of dependencyCleanups) cleanup();
+      for (const cleanup of effectCleanups) cleanup();
+    };
   }
 }
 
@@ -497,26 +1109,32 @@ class ScopeInstance extends RefCounter {
   }
 }
 
-interface Toposortable {
-  parents: Toposortable[];
-}
-function toposort<T extends Toposortable>(nodes: T[]): T[] {
+function toposort<T>(nodes: T[], getDependencies: (node: T) => T[]): T[] {
   const visited = new Set<T>();
   const result: T[] = [];
   function visit(current: T) {
     if (visited.has(current)) return;
     visited.add(current);
-    for (const parent of current.parents) visit(parent as T);
+    for (const dependency of getDependencies(current)) visit(dependency);
     result.push(current);
   }
   for (const node of nodes) visit(node);
   return result;
 }
+function toposortRequiredBunjas(bunjas: AnyBunja[]): AnyBunja[] {
+  return toposort(bunjas, (bunja) => bunja.requiredBunjas);
+}
+function toposortRelatedBunjas(bunjas: AnyBunja[]): AnyBunja[] {
+  return toposort(bunjas, (bunja) => [
+    ...bunja.requiredBunjas,
+    ...bunja.optionalBunjas,
+  ]);
+}
 
 const noop = () => {};
 
 export interface BunjaDevtoolsGlobalHook {
-  bunjas: Record<string, Bunja<any>>;
+  bunjas: Record<string, Bunja<any, any>>;
   scopes: Record<string, Scope<any>>;
   listeners: Record<
     BunjaDevtoolsEventType,

--- a/bunja/bunja.ts
+++ b/bunja/bunja.ts
@@ -141,7 +141,12 @@ interface BunjaInitFrame extends BunjaFrame {
 interface BunjaPrebakeFrame extends BunjaFrame {
   currentBunja: AnyBunja;
   readScope: ReadScope;
+  prebakeContext: BunjaPrebakeContext;
+}
+
+interface BunjaPrebakeContext {
   inProgressBunjas: Set<AnyBunja>;
+  values: Map<AnyBunja, unknown>;
 }
 
 type AnyNormalizedBunjaRef = NormalizedBunjaRef<any, any>;
@@ -277,6 +282,13 @@ function addUniqueBunjaRef(
   if (!refs.includes(ref)) refs.push(ref);
 }
 
+function createBunjaPrebakeContext(): BunjaPrebakeContext {
+  return {
+    inProgressBunjas: new Set(),
+    values: new Map(),
+  };
+}
+
 export class BunjaStore {
   private static counter: number = 0;
   readonly id: string = String(BunjaStore.counter++);
@@ -337,15 +349,14 @@ export class BunjaStore {
   prebake<T, Seed>(
     bunjaOrRef: Bunja<T, Seed> | BunjaPrebakeRef<T, Seed>,
     readScope: ReadScope,
-  ): BunjaStorePrebakeResult<T> {
+  ): BunjaStorePrebakeResult {
     const bunjaRef = normalizeBunjaPrebakeRef(bunjaOrRef);
-    const value = this.#prebakeBunjaRef(
+    this.#prebakeBunjaRef(
       bunjaRef,
       readScope,
-      new Set(),
+      createBunjaPrebakeContext(),
     );
     return {
-      value,
       relatedBunjas: bunjaRef.bunja.relatedBunjas,
       requiredScopes: bunjaRef.bunja.requiredScopes,
     };
@@ -654,9 +665,13 @@ export class BunjaStore {
   #prebakeBunjaRef<T, Seed>(
     bunjaRef: NormalizedBunjaRef<T, Seed>,
     readScope: ReadScope,
-    inProgressBunjas: Set<AnyBunja>,
+    prebakeContext: BunjaPrebakeContext,
   ): T {
     const { bunja } = bunjaRef;
+    if (prebakeContext.values.has(bunja)) {
+      return prebakeContext.values.get(bunja) as T;
+    }
+    const { inProgressBunjas } = prebakeContext;
     if (inProgressBunjas.has(bunja)) {
       throw new Error("Circular bunja dependency detected.");
     }
@@ -670,7 +685,7 @@ export class BunjaStore {
           const frame = this.#createPrebakeFrame(
             bunja,
             resolvedReadScope,
-            inProgressBunjas,
+            prebakeContext,
           );
           const value = runWithFrame(
             frame,
@@ -682,7 +697,8 @@ export class BunjaStore {
               ...bunja.requiredBunjaRefs,
               ...bunja.optionalBunjaRefs,
             ]
-          ) this.#prebakeBunjaRef(ref, resolvedReadScope, inProgressBunjas);
+          ) this.#prebakeBunjaRef(ref, resolvedReadScope, prebakeContext);
+          prebakeContext.values.set(bunja, value);
           return value;
         } finally {
           dispose();
@@ -695,12 +711,12 @@ export class BunjaStore {
   #createPrebakeFrame(
     currentBunja: AnyBunja,
     readScope: ReadScope,
-    inProgressBunjas: Set<AnyBunja>,
+    prebakeContext: BunjaPrebakeContext,
   ): BunjaPrebakeFrame {
     const frame = {
       currentBunja,
       readScope,
-      inProgressBunjas,
+      prebakeContext,
       use: ((dep: unknown, scopeValuePairs?: ScopeValuePairs) => {
         if (dep instanceof Scope) {
           if (!currentBunja.baked) {
@@ -729,7 +745,7 @@ export class BunjaStore {
         const value = this.#prebakeBunjaRef(
           bunjaRef,
           readScope,
-          inProgressBunjas,
+          prebakeContext,
         );
         return () => {
           if (frameStack[frameStack.length - 1] !== frame) {
@@ -757,7 +773,7 @@ export class BunjaStore {
     return this.#prebakeBunjaRef(
       bunjaRef,
       frame.readScope,
-      frame.inProgressBunjas,
+      frame.prebakeContext,
     );
   }
   #resolveScopeInstanceMap(
@@ -880,8 +896,7 @@ export interface BunjaStoreGetResult<T> {
   bunjaInstance?: BunjaInstance;
 }
 
-export interface BunjaStorePrebakeResult<T> {
-  value: T;
+export interface BunjaStorePrebakeResult {
   relatedBunjas: Bunja<any, any>[];
   requiredScopes: Scope<unknown>[];
 }

--- a/bunja/bunja.ts
+++ b/bunja/bunja.ts
@@ -94,7 +94,6 @@ export type Dep<T> = Bunja<T, any> | Scope<T>;
 
 type AnyBunja = Bunja<any, any>;
 type ScopeInstanceMap = Map<Scope<unknown>, ScopeInstance>;
-type BunjaDependencyEdge = "required" | "optional";
 
 interface BunjaFrame {
   use: BunjaUseFn;
@@ -564,11 +563,10 @@ export class BunjaStore {
           return this.#useScopeInFrame(frame, dep as Scope<unknown>);
         }
         if (dep instanceof Bunja || isBunjaRef(dep)) {
-          return this.#useBunjaDependencyInFrame(
-            frame,
-            normalizeBunjaRuntimeRef(dep, scopeValuePairs),
-            "required",
-          );
+          const bunjaRef = normalizeBunjaRuntimeRef(dep, scopeValuePairs);
+          const graphRef = toBunjaGraphRef(bunjaRef);
+          currentBunja.addRequiredBunjaRef(graphRef);
+          return this.#useBunjaDependencyInFrame(frame, bunjaRef);
         }
         throw new Error("`bunja.use` can only be used with Bunja or Scope.");
       }) as BunjaUseFn,
@@ -577,18 +575,15 @@ export class BunjaStore {
           throw new Error("`bunja.will` can only be used with Bunja.");
         }
         const bunjaRef = normalizeBunjaRuntimeRef(dep, scopeValuePairs);
-        currentBunja.addOptionalBunjaRef(toBunjaGraphRef(bunjaRef));
+        const graphRef = toBunjaGraphRef(bunjaRef);
+        currentBunja.addOptionalBunjaRef(graphRef);
         return () => {
           if (frameStack[frameStack.length - 1] !== frame) {
             throw new Error(
               "A thunk returned by `bunja.will` can only be called inside the same bunja init function.",
             );
           }
-          return this.#useBunjaDependencyInFrame(
-            frame,
-            bunjaRef,
-            "optional",
-          );
+          return this.#useBunjaDependencyInFrame(frame, bunjaRef);
         };
       }) as BunjaWillFn,
       effect: ((callback: BunjaEffectCallback) => {
@@ -619,14 +614,8 @@ export class BunjaStore {
   #useBunjaDependencyInFrame<T, Seed>(
     frame: BunjaInitFrame,
     bunjaRef: NormalizedBunjaRuntimeRef<T, Seed>,
-    edge: BunjaDependencyEdge,
   ): T {
     const graphRef = toBunjaGraphRef(bunjaRef);
-    if (edge === "optional" || graphRef.scopeValuePairs.length > 0) {
-      frame.currentBunja.addOptionalBunjaRef(graphRef);
-    } else if (edge === "required") {
-      frame.currentBunja.addRequiredBunjaRef(graphRef);
-    }
     const resolved = this.#resolveBunjaRef(
       graphRef,
       frame.readScope,
@@ -729,11 +718,14 @@ export class BunjaStore {
           return readScope(dep as Scope<unknown>);
         }
         if (dep instanceof Bunja || isBunjaRef(dep)) {
-          const bunjaRef = normalizeBunjaRuntimeRef(dep, scopeValuePairs);
-          return this.#prebakeBunjaDependencyInFrame(
-            frame,
-            toBunjaGraphRef(bunjaRef),
-            "required",
+          const bunjaRef = toBunjaGraphRef(
+            normalizeBunjaRuntimeRef(dep, scopeValuePairs),
+          );
+          currentBunja.addRequiredBunjaRef(bunjaRef);
+          return this.#prebakeBunjaRef(
+            bunjaRef,
+            readScope,
+            prebakeContext,
           );
         }
         throw new Error("`bunja.use` can only be used with Bunja or Scope.");
@@ -763,22 +755,6 @@ export class BunjaStore {
       effect: noop,
     } satisfies BunjaPrebakeFrame;
     return frame;
-  }
-  #prebakeBunjaDependencyInFrame<T, Seed>(
-    frame: BunjaPrebakeFrame,
-    bunjaRef: NormalizedBunjaRef<T, Seed>,
-    edge: BunjaDependencyEdge,
-  ): T {
-    if (edge === "optional" || bunjaRef.scopeValuePairs.length > 0) {
-      frame.currentBunja.addOptionalBunjaRef(bunjaRef);
-    } else if (edge === "required") {
-      frame.currentBunja.addRequiredBunjaRef(bunjaRef);
-    }
-    return this.#prebakeBunjaRef(
-      bunjaRef,
-      frame.readScope,
-      frame.prebakeContext,
-    );
   }
   #resolveScopeInstanceMap(
     bunja: AnyBunja,
@@ -988,8 +964,11 @@ export class Bunja<T, Seed = NoSeed> {
     const requiredBunjas = this.requiredBunjas;
     const expandedRequiredBunjas = toposortRequiredBunjas(requiredBunjas);
     const requiredScopeSet = new Set<Scope<unknown>>();
-    for (const bunja of expandedRequiredBunjas) {
-      for (const scope of bunja.requiredScopes) requiredScopeSet.add(scope);
+    for (const ref of requiredBunjaRefs) {
+      const boundScopes = getBoundScopeSet(ref.scopeValuePairs);
+      for (const scope of ref.bunja.requiredScopes) {
+        if (!boundScopes.has(scope)) requiredScopeSet.add(scope);
+      }
     }
     for (const scope of scopes) requiredScopeSet.add(scope);
     const requiredScopes = Array.from(requiredScopeSet);

--- a/bunja/package.json
+++ b/bunja/package.json
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "clean": "rm -rf ./dist",
-    "build": "tsdown"
+    "build": "tsdown --format cjs && tsdown --format esm --no-clean"
   },
   "keywords": [
     "bunja",

--- a/bunja/react.ts
+++ b/bunja/react.ts
@@ -12,6 +12,7 @@ import {
 } from "react";
 import {
   type Bunja,
+  type BunjaGetRef,
   type BunjaStore,
   createBunjaStore,
   createReadScopeFn,
@@ -20,12 +21,16 @@ import {
   type HashFn,
   type ReadScope,
   type Scope,
-  type ScopeValuePair,
+  type ScopeValuePairs,
 } from "./bunja.ts";
+import * as React from "react";
 
 // @ts-ignore dev
 // deno-lint-ignore no-process-global
 const __DEV__ = process.env.NODE_ENV !== "production";
+const reactUse = (React as unknown as {
+  use?: <T>(usable: Context<T>) => T;
+}).use;
 
 export const BunjaStoreContext: Context<BunjaStore> = createContext(
   createBunjaStore(),
@@ -40,7 +45,13 @@ export function BunjaStoreProvider(
 }
 
 export const scopeContextMap: Map<Scope<unknown>, Context<unknown>> = new Map();
+let scopeContextMapLocked = false;
 export function bindScope<T>(scope: Scope<T>, context: Context<T>): void {
+  if (__DEV__ && !reactUse && scopeContextMapLocked) {
+    throw new Error(
+      "`bindScope` must be called before rendering when using React 18.",
+    );
+  }
   scopeContextMap.set(scope as Scope<unknown>, context as Context<unknown>);
 }
 
@@ -53,16 +64,31 @@ export function createScopeFromContext<T>(
   return scope;
 }
 
-const defaultReadScope: ReadScope = <T>(scope: Scope<T>) => {
-  const context = scopeContextMap.get(scope as Scope<unknown>)!;
-  return useContext(context) as T;
-};
+function useScopeContextValues(): Map<Scope<unknown>, unknown> | undefined {
+  if (reactUse) return undefined;
+  scopeContextMapLocked = true;
+  return new Map(
+    Array.from(scopeContextMap, ([scope, context]) => [
+      scope,
+      useContext(context),
+    ]),
+  );
+}
 
-export function useBunja<T>(
-  bunja: Bunja<T>,
-  scopeValuePairs?: ScopeValuePair<any>[],
+export function useBunja<T, Seed>(
+  bunja: Bunja<T, Seed> | BunjaGetRef<T, Seed>,
+  scopeValuePairs?: ScopeValuePairs,
 ): T {
   const store = useContext(BunjaStoreContext);
+  const scopeContextValues = useScopeContextValues();
+  const defaultReadScope: ReadScope = <T>(scope: Scope<T>) => {
+    const context = scopeContextMap.get(scope as Scope<unknown>) as
+      | Context<T>
+      | undefined;
+    if (!context) throw new Error("Scope is not bound to a React context.");
+    if (reactUse) return reactUse(context);
+    return scopeContextValues!.get(scope as Scope<unknown>) as T;
+  };
   const readScope = scopeValuePairs
     ? createReadScopeFn(scopeValuePairs, defaultReadScope)
     : defaultReadScope;

--- a/bunja/solid.ts
+++ b/bunja/solid.ts
@@ -14,6 +14,7 @@ import {
 } from "solid-js";
 import {
   type Bunja,
+  type BunjaGetRef,
   type BunjaStore,
   createBunjaStore,
   createReadScopeFn,
@@ -21,7 +22,7 @@ import {
   type HashFn,
   type ReadScope,
   type Scope,
-  type ScopeValuePair,
+  type ScopeValuePairs,
 } from "./bunja.ts";
 
 type MaybeAccessor<T> = T | Accessor<T>;
@@ -82,8 +83,8 @@ const defaultReadScope: ReadScope = <T>(scope: Scope<T>) => {
 };
 
 export function useBunja<T>(
-  bunja: MaybeAccessor<Bunja<T>>,
-  scopeValuePairs?: MaybeAccessor<ScopeValuePair<any>[]>,
+  bunja: MaybeAccessor<Bunja<T, any> | BunjaGetRef<T, any>>,
+  scopeValuePairs?: MaybeAccessor<ScopeValuePairs>,
 ): Accessor<T> {
   const store = useContext(BunjaStoreContext);
   const readScope = createMemo(() => {

--- a/bunja/test.ts
+++ b/bunja/test.ts
@@ -1,7 +1,8 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { assertSpyCalls, spy } from "@std/testing/mock";
 
 import { bunja, createBunjaStore, createScope } from "./bunja.ts";
+import type { Bunja, BunjaRef } from "./bunja.ts";
 
 const readNull = <T>() => (null as T);
 
@@ -207,7 +208,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "fork",
+  name: "bunja.use can override scope value pairs inside a bunja init",
   fn() {
     const store = createBunjaStore();
     const aaScope = createScope<string>();
@@ -227,8 +228,8 @@ Deno.test({
       return { a, scopeValue };
     });
     const cBunja = bunja(() => {
-      const foo = bunja.fork(bBunja, [aaScope.bind("foo")]);
-      const bar = bunja.fork(bBunja, [aaScope.bind("bar")]);
+      const foo = bunja.use(bBunja, [aaScope.bind("foo")]);
+      const bar = bunja.use(bBunja, [aaScope.bind("bar")]);
       bunja.effect(() => (cMountSpy(), cUnmountSpy));
       return { foo, bar };
     });
@@ -268,5 +269,401 @@ Deno.test({
     assertSpyCalls(aUnmountSpy, 1);
     assertSpyCalls(bUnmountSpy, 2);
     assertSpyCalls(cUnmountSpy, 1);
+  },
+});
+
+Deno.test({
+  name: "seed is used only when creating a bunja instance",
+  fn() {
+    const store = createBunjaStore();
+    const myBunja = bunja.withSeed({ value: "default" }, (seed) => ({ seed }));
+
+    const { value: firstValue, mount: firstMount } = store.get(
+      { bunja: myBunja, seed: { value: "first" } },
+      readNull,
+    );
+    const firstCleanup = firstMount();
+
+    const { value: secondValue, mount: secondMount } = store.get(
+      { bunja: myBunja, seed: { value: "second" } },
+      readNull,
+    );
+    const secondCleanup = secondMount();
+
+    assertEquals(firstValue.seed.value, "first");
+    assertEquals(secondValue, firstValue);
+
+    firstCleanup();
+    secondCleanup();
+
+    const { value: thirdValue, mount: thirdMount } = store.get(
+      { bunja: myBunja, seed: { value: "third" } },
+      readNull,
+    );
+    const thirdCleanup = thirdMount();
+
+    assertEquals(thirdValue.seed.value, "third");
+    thirdCleanup();
+  },
+});
+
+Deno.test({
+  name: "bunja.use can provide seed without storing it in graph refs",
+  fn() {
+    const store = createBunjaStore();
+    const seededDependencyBunja = bunja.withSeed(
+      { value: "default" },
+      (seed) => seed.value,
+    );
+    const seededDependencyRef: BunjaRef<string, { value: string }> = {
+      bunja: seededDependencyBunja,
+      seed: { value: "dependency" },
+    };
+    const consumerBunja = bunja(() => {
+      return bunja.use(seededDependencyRef);
+    });
+
+    const { value, mount } = store.get(consumerBunja, readNull);
+    const cleanup = mount();
+
+    assertEquals(value, "dependency");
+    assertEquals(consumerBunja.requiredBunjaRefs.length, 1);
+    assertEquals("seed" in consumerBunja.requiredBunjaRefs[0], false);
+
+    cleanup();
+  },
+});
+
+Deno.test({
+  name: "prebake cannot provide seed and uses the default seed",
+  fn() {
+    const store = createBunjaStore();
+    const myBunja = bunja.withSeed({ value: "default" }, (seed) => seed.value);
+    const myRef: BunjaRef<string, { value: string }> = {
+      bunja: myBunja,
+      seed: { value: "custom" },
+    };
+    const consumerBunja = bunja(() => bunja.use(myRef));
+
+    const prebaked = store.prebake(myBunja, readNull);
+    const prebakedConsumer = store.prebake(consumerBunja, readNull);
+
+    assertEquals(prebaked.value, "default");
+    assertEquals(prebakedConsumer.value, "default");
+    assertEquals("seed" in consumerBunja.requiredBunjaRefs[0], false);
+    assertThrows(
+      () => {
+        // @ts-expect-error Prebake collects deterministic graph data only.
+        store.prebake(myRef, readNull);
+      },
+      Error,
+      "seed cannot be provided to `store.prebake`",
+    );
+  },
+});
+
+Deno.test({
+  name: "bunja.will mounts only the selected dependency",
+  fn() {
+    const store = createBunjaStore();
+    const condScope = createScope<"a" | "b">();
+    const [aMountSpy, aUnmountSpy] = [spy(), spy()];
+    const [bMountSpy, bUnmountSpy] = [spy(), spy()];
+    const aBunja = bunja(() => {
+      bunja.effect(() => (aMountSpy(), aUnmountSpy));
+      return "a";
+    });
+    const bBunja = bunja(() => {
+      bunja.effect(() => (bMountSpy(), bUnmountSpy));
+      return "b";
+    });
+    const consumerBunja = bunja(() => {
+      const cond = bunja.use(condScope);
+      const getA = bunja.will(aBunja);
+      const getB = bunja.will(bBunja);
+      return cond === "a" ? getA() : getB();
+    });
+
+    const { value, mount } = store.get(
+      consumerBunja,
+      <T>() => "a" as T,
+    );
+    assertEquals(value, "a");
+    assertEquals(consumerBunja.relatedBunjas, [aBunja, bBunja]);
+
+    const cleanup = mount();
+    assertSpyCalls(aMountSpy, 1);
+    assertSpyCalls(bMountSpy, 0);
+
+    cleanup();
+    assertSpyCalls(aUnmountSpy, 1);
+    assertSpyCalls(bUnmountSpy, 0);
+  },
+});
+
+Deno.test({
+  name: "relatedBunjas includes nested bunja.will dependencies",
+  fn() {
+    const store = createBunjaStore();
+    const grandparentDependencyBunja = bunja(() => "grandparent");
+    const parentDependencyBunja = bunja(() => {
+      bunja.will(grandparentDependencyBunja);
+      return "parent";
+    });
+    const consumerBunja = bunja(() => {
+      const getParent = bunja.will(parentDependencyBunja);
+      return getParent();
+    });
+
+    const { mount } = store.get(consumerBunja, readNull);
+    const cleanup = mount();
+
+    assertEquals(consumerBunja.relatedBunjas, [
+      grandparentDependencyBunja,
+      parentDependencyBunja,
+    ]);
+
+    cleanup();
+  },
+});
+
+Deno.test({
+  name: "prebake expands inactive bunja.will dependency graph",
+  fn() {
+    const store = createBunjaStore();
+    const grandparentDependencyMountSpy = spy();
+    const grandparentDependencyBunja = bunja(() => {
+      bunja.effect(() => {
+        grandparentDependencyMountSpy();
+      });
+      return "grandparent";
+    });
+    const parentDependencyBunja = bunja(() => {
+      bunja.will(grandparentDependencyBunja);
+      return "parent";
+    });
+    const consumerBunja = bunja(() => {
+      bunja.will(parentDependencyBunja);
+      return "consumer";
+    });
+
+    const { value, mount } = store.get(consumerBunja, readNull);
+    const cleanup = mount();
+
+    assertEquals(value, "consumer");
+    assertEquals(consumerBunja.relatedBunjas, [parentDependencyBunja]);
+    assertSpyCalls(grandparentDependencyMountSpy, 0);
+
+    const prebaked = store.prebake(consumerBunja, readNull);
+
+    assertEquals(prebaked.value, "consumer");
+    assertEquals(prebaked.relatedBunjas, [
+      grandparentDependencyBunja,
+      parentDependencyBunja,
+    ]);
+    assertEquals(consumerBunja.relatedBunjas, [
+      grandparentDependencyBunja,
+      parentDependencyBunja,
+    ]);
+    assertSpyCalls(grandparentDependencyMountSpy, 0);
+
+    cleanup();
+  },
+});
+
+Deno.test({
+  name: "prebake disposes the dry-run wrapper",
+  fn() {
+    const disposeSpy = spy();
+    let wrapCalls = 0;
+    const store = createBunjaStore({
+      wrapInstance: (fn) => {
+        wrapCalls++;
+        return fn(disposeSpy);
+      },
+    });
+    const myBunja = bunja(() => "value");
+
+    const prebaked = store.prebake(myBunja, readNull);
+
+    assertEquals(prebaked.value, "value");
+    assertEquals(wrapCalls, 1);
+    assertSpyCalls(disposeSpy, 1);
+  },
+});
+
+Deno.test({
+  name: "bunja.will thunk can only be called during the same bunja init",
+  fn() {
+    const store = createBunjaStore();
+    const parentDependencyBunja = bunja(() => "parent");
+    let getParent!: () => string;
+    const consumerBunja = bunja(() => {
+      getParent = bunja.will(parentDependencyBunja);
+      return {};
+    });
+
+    const { mount } = store.get(consumerBunja, readNull);
+    const cleanup = mount();
+
+    assertThrows(
+      () => getParent(),
+      Error,
+      "same bunja init function",
+    );
+
+    cleanup();
+  },
+});
+
+Deno.test({
+  name: "store.get rejects circular bunja dependencies",
+  fn() {
+    const disposeSpy = spy();
+    const store = createBunjaStore({
+      wrapInstance: (fn) => fn(disposeSpy),
+    });
+    let bBunja!: Bunja<string>;
+    const aBunja = bunja(() => bunja.use(bBunja));
+    bBunja = bunja(() => bunja.use(aBunja));
+
+    assertThrows(
+      () => store.get(aBunja, readNull),
+      Error,
+      "Circular bunja dependency detected.",
+    );
+    assertSpyCalls(disposeSpy, 2);
+  },
+});
+
+Deno.test({
+  name: "prebake rejects circular bunja dependencies",
+  fn() {
+    const store = createBunjaStore();
+    let bBunja!: Bunja<string>;
+    const aBunja = bunja(() => bunja.use(bBunja));
+    bBunja = bunja(() => bunja.use(aBunja));
+
+    assertThrows(
+      () => store.prebake(aBunja, readNull),
+      Error,
+      "Circular bunja dependency detected.",
+    );
+  },
+});
+
+Deno.test({
+  name: "active optional dependency scopes are part of bunja instance identity",
+  fn() {
+    const store = createBunjaStore();
+    const condScope = createScope<boolean>();
+    const resourceScope = createScope<string>();
+    const mounted: string[] = [];
+    const unmounted: string[] = [];
+    const parentDependencyBunja = bunja(() => {
+      const resource = bunja.use(resourceScope);
+      bunja.effect(() => {
+        mounted.push(resource);
+        return () => unmounted.push(resource);
+      });
+      return { resource };
+    });
+    const consumerBunja = bunja(() => {
+      const cond = bunja.use(condScope);
+      const getParent = bunja.will(parentDependencyBunja);
+      return { parent: cond ? getParent() : null };
+    });
+    const readScope = (resource: string) => <T>(scope: unknown) =>
+      (scope === condScope ? true : resource) as T;
+
+    const first = store.get(consumerBunja, readScope("a"));
+    const firstCleanup = first.mount();
+    const second = store.get(consumerBunja, readScope("b"));
+    const secondCleanup = second.mount();
+
+    assertEquals(consumerBunja.requiredScopes.length, 1);
+    assertEquals(consumerBunja.requiredScopes[0] === condScope, true);
+    assertEquals(first.value.parent?.resource, "a");
+    assertEquals(second.value.parent?.resource, "b");
+    assertEquals(first.value === second.value, false);
+    assertEquals(first.deps, [true, "a"]);
+    assertEquals(second.deps, [true, "b"]);
+    assertEquals(mounted, ["a", "b"]);
+
+    firstCleanup();
+    assertEquals(unmounted, ["a"]);
+    secondCleanup();
+    assertEquals(unmounted, ["a", "b"]);
+  },
+});
+
+Deno.test({
+  name:
+    "inactive optional dependency scopes do not change bunja instance identity",
+  fn() {
+    const store = createBunjaStore();
+    const condScope = createScope<boolean>();
+    const resourceScope = createScope<string>();
+    const parentDependencyMountSpy = spy();
+    const parentDependencyBunja = bunja(() => {
+      bunja.use(resourceScope);
+      bunja.effect(() => {
+        parentDependencyMountSpy();
+      });
+      return {};
+    });
+    const consumerBunja = bunja(() => {
+      const cond = bunja.use(condScope);
+      const getParent = bunja.will(parentDependencyBunja);
+      return { parent: cond ? getParent() : null };
+    });
+    const readScope = (resource: string) => <T>(scope: unknown) =>
+      (scope === condScope ? false : resource) as T;
+
+    const first = store.get(consumerBunja, readScope("a"));
+    const second = store.get(consumerBunja, readScope("b"));
+    const firstCleanup = first.mount();
+    const secondCleanup = second.mount();
+
+    assertEquals(consumerBunja.requiredScopes.length, 1);
+    assertEquals(consumerBunja.requiredScopes[0] === condScope, true);
+    assertEquals(first.value, second.value);
+    assertEquals(first.deps, [false]);
+    assertEquals(second.deps, [false]);
+    assertSpyCalls(parentDependencyMountSpy, 0);
+
+    firstCleanup();
+    secondCleanup();
+  },
+});
+
+Deno.test({
+  name: "duplicate optional dependency calls are mounted once",
+  fn() {
+    const store = createBunjaStore();
+    const mountSpy = spy();
+    const parentDependencyValue = {};
+    const parentDependencyBunja = bunja(() => {
+      bunja.effect(() => {
+        mountSpy();
+      });
+      return parentDependencyValue;
+    });
+    const consumerBunja = bunja(() => {
+      const getParent = bunja.will(parentDependencyBunja);
+      return {
+        first: getParent(),
+        second: getParent(),
+      };
+    });
+
+    const { value, mount } = store.get(consumerBunja, readNull);
+    const cleanup = mount();
+
+    assertEquals(value.first, parentDependencyValue);
+    assertEquals(value.second, parentDependencyValue);
+    assertSpyCalls(mountSpy, 1);
+
+    cleanup();
   },
 });

--- a/bunja/test.ts
+++ b/bunja/test.ts
@@ -208,6 +208,32 @@ Deno.test({
 });
 
 Deno.test({
+  name: "root scope value pairs are included in store.get deps",
+  fn() {
+    const store = createBunjaStore();
+    const myScope = createScope<string>();
+    const myBunja = bunja(() => {
+      const scopeValue = bunja.use(myScope);
+      return { scopeValue };
+    });
+
+    const first = store.get(
+      { bunja: myBunja, with: [myScope.bind("foo")] },
+      readNull,
+    );
+    const second = store.get(
+      { bunja: myBunja, with: [myScope.bind("bar")] },
+      readNull,
+    );
+
+    assertEquals(first.value.scopeValue, "foo");
+    assertEquals(second.value.scopeValue, "bar");
+    assertEquals(first.deps, ["foo"]);
+    assertEquals(second.deps, ["bar"]);
+  },
+});
+
+Deno.test({
   name: "bunja.use can override scope value pairs inside a bunja init",
   fn() {
     const store = createBunjaStore();

--- a/bunja/test.ts
+++ b/bunja/test.ts
@@ -335,21 +335,24 @@ Deno.test({
 });
 
 Deno.test({
-  name: "prebake cannot provide seed and uses the default seed",
+  name: "prebake rejects root seed and initializes with default seed",
   fn() {
     const store = createBunjaStore();
-    const myBunja = bunja.withSeed({ value: "default" }, (seed) => seed.value);
+    const usedSeeds: string[] = [];
+    const myBunja = bunja.withSeed({ value: "default" }, (seed) => {
+      usedSeeds.push(seed.value);
+      return seed.value;
+    });
     const myRef: BunjaRef<string, { value: string }> = {
       bunja: myBunja,
       seed: { value: "custom" },
     };
     const consumerBunja = bunja(() => bunja.use(myRef));
 
-    const prebaked = store.prebake(myBunja, readNull);
-    const prebakedConsumer = store.prebake(consumerBunja, readNull);
+    store.prebake(myBunja, readNull);
+    store.prebake(consumerBunja, readNull);
 
-    assertEquals(prebaked.value, "default");
-    assertEquals(prebakedConsumer.value, "default");
+    assertEquals(usedSeeds, ["default", "default"]);
     assertEquals("seed" in consumerBunja.requiredBunjaRefs[0], false);
     assertThrows(
       () => {
@@ -456,7 +459,6 @@ Deno.test({
 
     const prebaked = store.prebake(consumerBunja, readNull);
 
-    assertEquals(prebaked.value, "consumer");
     assertEquals(prebaked.relatedBunjas, [
       grandparentDependencyBunja,
       parentDependencyBunja,
@@ -468,6 +470,38 @@ Deno.test({
     assertSpyCalls(grandparentDependencyMountSpy, 0);
 
     cleanup();
+  },
+});
+
+Deno.test({
+  name: "prebake runs each dependency once per traversal",
+  fn() {
+    const store = createBunjaStore();
+    const requiredInitSpy = spy();
+    const optionalInitSpy = spy();
+    const requiredDependencyBunja = bunja(() => {
+      requiredInitSpy();
+      return "required";
+    });
+    const optionalDependencyBunja = bunja(() => {
+      optionalInitSpy();
+      return "optional";
+    });
+    const consumerBunja = bunja(() => {
+      const required = bunja.use(requiredDependencyBunja);
+      const getOptional = bunja.will(optionalDependencyBunja);
+      return `${required}:${getOptional()}`;
+    });
+
+    store.prebake(consumerBunja, readNull);
+
+    assertSpyCalls(requiredInitSpy, 1);
+    assertSpyCalls(optionalInitSpy, 1);
+
+    store.prebake(consumerBunja, readNull);
+
+    assertSpyCalls(requiredInitSpy, 2);
+    assertSpyCalls(optionalInitSpy, 2);
   },
 });
 
@@ -484,9 +518,8 @@ Deno.test({
     });
     const myBunja = bunja(() => "value");
 
-    const prebaked = store.prebake(myBunja, readNull);
+    store.prebake(myBunja, readNull);
 
-    assertEquals(prebaked.value, "value");
     assertEquals(wrapCalls, 1);
     assertSpyCalls(disposeSpy, 1);
   },

--- a/bunja/test.ts
+++ b/bunja/test.ts
@@ -299,6 +299,56 @@ Deno.test({
 });
 
 Deno.test({
+  name: "bunja.use with scope value pairs propagates unbound required scopes",
+  fn() {
+    const createGraph = () => {
+      const injectedScope = createScope<string>();
+      const outerScope = createScope<string>();
+      const dependencyBunja = bunja(() => {
+        const injected = bunja.use(injectedScope);
+        const outer = bunja.use(outerScope);
+        return { injected, outer };
+      });
+      const consumerBunja = bunja(() =>
+        bunja.use(dependencyBunja, [injectedScope.bind("injected")])
+      );
+      return { consumerBunja, injectedScope, outerScope };
+    };
+    const readScope = <T>() => "outer" as T;
+
+    const prebakeGraph = createGraph();
+    const { requiredScopes } = createBunjaStore().prebake(
+      prebakeGraph.consumerBunja,
+      readScope,
+    );
+    assertEquals(requiredScopes.length, 1);
+    assertEquals(requiredScopes[0] === prebakeGraph.outerScope, true);
+    assertEquals(
+      requiredScopes.some((scope) => scope === prebakeGraph.injectedScope),
+      false,
+    );
+
+    const getGraph = createGraph();
+    const { value, deps } = createBunjaStore().get(
+      getGraph.consumerBunja,
+      readScope,
+    );
+    const requiredScopes2 = getGraph.consumerBunja.requiredScopes;
+    assertEquals(value, { injected: "injected", outer: "outer" });
+    assertEquals(deps, ["outer"]);
+    assertEquals(requiredScopes2.length, 1);
+    assertEquals(
+      requiredScopes2[0] === getGraph.outerScope,
+      true,
+    );
+    assertEquals(
+      requiredScopes2.some((scope) => scope === getGraph.injectedScope),
+      false,
+    );
+  },
+});
+
+Deno.test({
   name: "seed is used only when creating a bunja instance",
   fn() {
     const store = createBunjaStore();
@@ -427,6 +477,29 @@ Deno.test({
     cleanup();
     assertSpyCalls(aUnmountSpy, 1);
     assertSpyCalls(bUnmountSpy, 0);
+  },
+});
+
+Deno.test({
+  name: "bunja.will records optional refs once when thunk is used",
+  fn() {
+    const createConsumer = () => {
+      const dependencyBunja = bunja(() => "dependency");
+      const consumerBunja = bunja(() => {
+        const getDependency = bunja.will(dependencyBunja);
+        return getDependency();
+      });
+      return { consumerBunja };
+    };
+
+    const getGraph = createConsumer();
+    createBunjaStore().get(getGraph.consumerBunja, readNull);
+
+    const prebakeGraph = createConsumer();
+    createBunjaStore().prebake(prebakeGraph.consumerBunja, readNull);
+
+    assertEquals(getGraph.consumerBunja.optionalBunjaRefs.length, 1);
+    assertEquals(prebakeGraph.consumerBunja.optionalBunjaRefs.length, 1);
   },
 });
 

--- a/examples/timer-solid/index.html
+++ b/examples/timer-solid/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
     <title>Bunja Timers • Modern Timer App</title>
     <meta
       name="description"

--- a/examples/timer/index.html
+++ b/examples/timer/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
     <title>Bunja Timers • Modern Timer App</title>
     <meta
       name="description"

--- a/examples/timer/src/App.tsx
+++ b/examples/timer/src/App.tsx
@@ -12,14 +12,13 @@ export function App() {
 
   const renderItem = (item: Item) => {
     const commonProps = {
-      key: item.id,
       id: item.id,
       onRemove: () => remove(item.id),
     };
 
     return item.type === "timer"
-      ? <Timer {...commonProps} />
-      : <Countdown {...commonProps} />;
+      ? <Timer key={item.id} {...commonProps} />
+      : <Countdown key={item.id} {...commonProps} />;
   };
 
   return (


### PR DESCRIPTION
## Summary

This PR introduces the v3 dependency graph model for Bunja.

The main additions are `bunja.withSeed`, `bunja.will`, bunja refs, active optional dependency tracking, and `store.prebake`. Together they allow a bunja to declare possible dependencies statically while mounting only the dependency branch that is actually used by the first instance creation.

## What Changed

### Seeded bunjas

- Added `bunja.withSeed(defaultSeed, init)`.
- `seed` is creation-time data for the first matching bunja instance.
- `seed` is not part of the bunja instance identity.
- If an instance already exists, later seed values are ignored.
- `store.get`, `useBunja`, `bunja.use`, and `bunja.will` can receive bunja refs with `seed`.

### Conditional dependencies

- Added `bunja.will`.
- `bunja.will(dep)` declares a possible bunja dependency and returns a thunk.
- Only the called thunk becomes an active dependency and gets mounted.
- The thunk can only be called during the same bunja init function that created it.
- `bunja.use` and `bunja.will` must still be called unconditionally and in a stable order, similar to React’s Rules of Hooks.

### Scope value pairs

- Bunja refs and `bunja.use`/`bunja.will` can provide scope value pairs.
- The selected bunja and the provided scope value pair list must be static.
- Dynamic `seed` values are allowed because they are not recorded in the dependency graph.
- Scope value pairs are used to override scope values while resolving a dependency.

### Instance identity

- Bunja instance ids now include active optional dependency ids.
- This means a bunja can resolve to different instances depending on which `bunja.will` branch is actually selected.
- Scopes used by active optional dependencies are reflected in the consuming bunja instance identity.
- Inactive optional dependencies do not create or mount instances.

### Prebaking

- Added `store.prebake`.
- Prebake runs bunja init functions in a dry graph-collection mode.
- It does not create ref-counted instances, mount dependencies, or run effects.
- It is intended for devtools/debugging cases where optional `bunja.will` dependency graphs should be discovered ahead of time.
- Root seed is intentionally not accepted by `store.prebake`; default seeds are used for deterministic graph collection.

### Graph metadata cleanup

- Renamed `relatedScopes` to `requiredScopes`.
- `relatedBunjas` is now derived from required and optional bunja dependencies.
- Added explicit required/optional dependency tracking internally.
- Added circular dependency guards for both normal `store.get` and `store.prebake`.

### Adapter updates

- React adapter now accepts bunja refs in `useBunja`.
- React 19 uses `React.use` for scoped context reads when available.
- React 18 falls back to reading all bound contexts and requires scopes to be bound before rendering.
- Solid adapter now accepts bunja refs in `useBunja`.

### Removed

- Removed `bunja.fork`.
- Scope overrides should now use `bunja.use(dep, scopeValuePairs)` or bunja refs.
